### PR TITLE
Adds check to iterfollow to avoid unwanted exception

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -478,6 +478,8 @@ class Zotero(object):
         """ Generator for self.follow()
         """
         # use same criterion as self.follow()
+        if self.links is None:
+            return
         while self.links.get('next'):
             yield self.follow()
 


### PR DESCRIPTION
This is needed to avoid an AttributeError if self.links was not previously populated. 

To reproduce:

1) Make a request that returns a multi object with a limit higher than the number of currently stored items in Zotero.The response will not include a start or last link in the header and the self.links attribute will not get populated.
2) Try to use iterfollow()

Working example:

GET https://api.zotero.org/users/475425/collections?v=3&limit=1

Will get you a header:

Link    https://api.zotero.org/users/475425/collections?limit=1&start=1&v=3; rel="next", https://api.zotero.org/users/475425/collections?limit=1&start=14&v=3; rel="last", <https://www.zotero.org/users/475425

Failing example:

GET https://api.zotero.org/users/475425/collections?v=3&limit=100

Will get you a header with:

Link    https://www.zotero.org/users/475425/collections; rel="alternate"
