### PR TITLE
Add method to retrieve the last modified version

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -463,6 +463,19 @@ If you wish to retrieve item counts for subsets of a library, you can use the fo
 
 .. _parameters:
 
+================================
+Retrieving last modified version
+================================
+
+If you wish to retrieve the last modified version of a library, you can use the following method:
+
+.. py:method:: Zotero.last_modified_version()
+
+    Returns the last modified version of the library
+
+    :rtype: int
+
+
 ==============================================
 Search / Request Parameters for Read API calls
 ==============================================

--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -388,6 +388,12 @@ class Zotero(object):
         query_string = '/{t}/{u}/items'
         return self._build_query(query_string)
 
+    def last_modified_version(self, **kwargs):
+        """ Get the last modified version
+        """
+        self.items(**kwargs)
+        return int(self.request.headers.get('last-modified-version', 0))
+
     @retrieve
     def top(self, **kwargs):
         """ Get user top-level items


### PR DESCRIPTION
There is no way in pyzotero to obtain the last modified version of a library. We used to use version of the last modified item, but when you modify a tag of an item, it doesn't become the last item (and its modifiedDate doesn't change either, so you can't do something like zotero.items(limit=1,sort='modifiedDate') ). 

A new method which retrieves the last-modified-version header is provided.

Best,