### PR TITLE
Fix create_collection to match the API and recent changes

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -973,10 +973,10 @@ class Zotero(object):
     def create_collection(self, payload):
         """
         Create a new Zotero collection
-        Accepts one argument, a dict containing the following keys:
+        Accepts one argument, a list of dicts containing the following keys:
 
         'name': the name of the collection
-        'parent': OPTIONAL, the parent collection to which you wish to add this
+        'parentCollection': OPTIONAL, the parent collection to which you wish to add this
         """
         # no point in proceeding if there's no 'name' key
         for item in payload:

--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -983,9 +983,9 @@ class Zotero(object):
             if 'name' not in item:
                 raise ze.ParamNotPassed(
                     "The dict you pass must include a 'name' key")
-            # add a blank 'parent' key if it hasn't been passed
+            # add a blank 'parentCollection' key if it hasn't been passed
             if not 'parentCollection' in item:
-                payload['parentCollection'] = ''
+                item['parentCollection'] = ''
         headers = {
             'Zotero-Write-Token': token(),
         }

--- a/test/test_zotero.py
+++ b/test/test_zotero.py
@@ -391,7 +391,7 @@ class ZoteroTests(unittest.TestCase):
         """ Ensure that collection creation fails with the wrong dict
         """
         zot = z.Zotero('myuserID', 'user', 'myuserkey')
-        t = {'foo': 'bar'}
+        t = [{'foo': 'bar'}]
         with self.assertRaises(z.ze.ParamNotPassed):
             t = zot.create_collection(t)
 


### PR DESCRIPTION
The API docs imply that create_collection requires a list of dicts, and a recent change in 2f762af agrees (by iterating over that list). API v3 also changes `parent` to `parentCollection`. This pull request fixes the documentation to match, and fixes a bug where the code attempts to add a missing `parentCollection` to the list rather than the dict.