### PR TITLE
fix 'addto_collection' error

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -1103,7 +1103,7 @@ class Zotero(object):
         ident = payload['key']
         modified = payload['version']
         # add the collection data from the item
-        modified_collections = payload['data']['collections'] + list(collection)
+        modified_collections = payload['data']['collections'] + [collection]
         headers = {'If-Unmodified-Since-Version': modified}
         headers.update(self.default_headers())
         req = requests.patch(


### PR DESCRIPTION
addto_collection raises error when collection argument is a string, because list function splits single string to a list of letters. 

Sorry for bad english.