### PR TITLE
add authorization header iff self.api_key exists

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -125,7 +125,7 @@ def retrieve(func):
             self.request.url) and \
             self.content.search(
                 self.request.url).group(0) or 'bib'
-       # JSON by default
+        # JSON by default
         formats = {
             'application/atom+xml': 'atom',
             'application/json': 'json',
@@ -168,8 +168,7 @@ class Zotero(object):
             raise ze.MissingCredentials(
                 'Please provide both the library ID and the library type')
         # api_key is not required for public individual or group libraries
-        if api_key:
-            self.api_key = api_key
+        self.api_key = api_key
         self.preserve_json_order = preserve_json_order
         self.url_params = None
         self.tag_data = False
@@ -215,11 +214,14 @@ class Zotero(object):
         """
         It's always OK to include these headers
         """
-        return {
+        _headers = {
             "User-Agent": "Pyzotero/%s" % __version__,
-            "Authorization": "Bearer %s" % self.api_key,
             "Zotero-API-Version": "%s" % __api_version__,
-            }
+        }
+        if self.api_key:
+            _headers["Authorization"] = "Bearer %s" % self.api_key,
+        return _headers
+
 
     def _cache(self, template, key):
         """
@@ -341,7 +343,7 @@ class Zotero(object):
             raise ze.ParamNotPassed(
                 'There\'s a request parameter missing: %s' % err)
         # Add the URL parameters and the user key, if necessary
-        if no_params == False:
+        if no_params is False:
             if not self.url_params:
                 self.add_parameters()
             query = '%s?%s' % (query, self.url_params)

--- a/test/test_zotero.py
+++ b/test/test_zotero.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 Tests for the Pyzotero module
@@ -227,7 +227,6 @@ class ZoteroTests(unittest.TestCase):
             "LoC",
             collections_data['data']['name'])
 
-
     @httpretty.activate
     def testParseCollectionsJSONDoc(self):
         """ Should successfully return a list of collection dicts, key should
@@ -386,6 +385,19 @@ class ZoteroTests(unittest.TestCase):
         t = [{'foo': 'bar'}]
         with self.assertRaises(z.ze.ParamNotPassed):
             t = zot.create_collection(t)
+
+    @httpretty.activate
+    def testNoApiKey(self):
+        """ Ensure that pyzotero works when api_key is not set
+        """
+        zot = z.Zotero('myuserID', 'user')
+        HTTPretty.register_uri(
+            HTTPretty.GET,
+            'https://api.zotero.org/users/myuserID/items',
+            content_type='application/json',
+            body=self.item_doc)
+        items = zot.items()
+        self.assertEqual(len(items), 6) # this isn't a very good assertion
 
     # @httpretty.activate
     # def testUpdateItem(self):


### PR DESCRIPTION
We were trying to use pyzotero to access a public group zotero library and without setting the third api_key parameter but it errors out with the following:

```
In [1]: from pyzotero import zotero

In [2]: z = zotero.Zotero(284000, 'group')

In [3]: z.top(limit=5)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-39727ccebd40> in <module>()
----> 1 z.top(limit=5)

~/.virtualenvs/catalog/local/lib/python2.7/site-packages/pyzotero/zotero.pyc in wrapped_f(self, *args, **kwargs)
    118         if kwargs:
    119             self.add_parameters(**kwargs)
--> 120         retrieved = self._retrieve_data(func(self, *args))
    121         # we now always have links in the header response
    122         self.links = self._extract_links()

~/.virtualenvs/catalog/local/lib/python2.7/site-packages/pyzotero/zotero.pyc in _retrieve_data(self, request)
    252         self.request = requests.get(
    253             url=full_url,
--> 254             headers=self.default_headers())
    255         try:
    256             self.request.raise_for_status()

~/.virtualenvs/catalog/local/lib/python2.7/site-packages/pyzotero/zotero.pyc in default_headers(self)
    218         return {
    219             "User-Agent": "Pyzotero/%s" % __version__,
--> 220             "Authorization": "Bearer %s" % self.api_key,
    221             "Zotero-API-Version": "%s" % __api_version__,
    222             }

AttributeError: 'Zotero' object has no attribute 'api_key'
```

This PR attempts to fix that by only adding the `"Authorization: Bearer ..."` header if self.api_key is set. I also added a very simple test.

Thanks for providing this library, and please let me know if you need me to adjust the PR in any way.

