### PR TITLE
This allows to search multiple tags with "AND" logic

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -326,7 +326,7 @@ class Zotero(object):
             params['format'] = 'atom'
         # TODO: rewrite format=atom, content=json request
 
-        self.url_params = urlencode(params)
+        self.url_params = urlencode(params, doseq=True)
 
     def _build_query(self, query_string, no_params=False):
         """


### PR DESCRIPTION
Zotero API search syntax support AND logic for 'tag' parametr with syntax "tag=foo&tag=bar". Its imposible to make such search now because we cant pass arguments with tha same value to `Zotero.add_parametrs(**kwargs)`  like `Zotero.add_parametrs(tag='foo', tag='bar')`. Also we cant use `Zotero.add_parametrs(tag='foo&tag=bar')` because '&' and = symbols will be percent-encoded by `urlencode`.

This fix allows to add tag parametrs as a list `Zotero.add_parametrs(tag=['foo','bar'])`. This syntax isnt obvious and shoud be included in docs, but I don't know how to write it right and clear. 