### PR TITLE
added function to retrieve deleted collections, items, tags, searches…

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -167,6 +167,12 @@ The following methods will retrieve either user or group items, depending on the
 
         :rtype: list of dicts
 
+    .. py:method:: Zotero.deleted([search/request parameters])
+
+        Returns deleted collections, library items, tags, searches and settings (requires "since=" parameter)
+
+        :rtype: list of dicts
+
     .. py:method:: Zotero.item(itemID[, search/request parameters])
 
         Returns a specific item

--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -430,6 +430,13 @@ class Zotero(object):
         return self._build_query(query_string)
 
     @retrieve
+    def deleted(self, **kwargs):
+        """ Get all deleted items (requires since= parameter)
+        """
+        query_string = '/{t}/{u}/deleted'
+        return self._build_query(query_string)
+
+    @retrieve
     def item(self, item, **kwargs):
         """ Get a specific item
         """


### PR DESCRIPTION
… and settings

The "deleted" method is part of zotero API 3 and required for an incremental sync. 
Would be great to have it in pyzotero !

- Lars