### PR TITLE
Updating attachment items

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -793,7 +793,13 @@ class Zotero(object):
             'version',
             'collections',
             'dateModified',
-            'relations'])
+            'relations',
+            #  attachment items
+            'parentItem',
+            'mtime',
+            'contentType',
+            'md5',
+            'filename'])
         template = template | set(self.temp_keys)
         for pos, item in enumerate(items):
             to_check = set(i for i in list(item['data'].keys()))


### PR DESCRIPTION
Hi there,

When I tried to update items representing attachments (retrieved with `Zotero.children()`) I got an error for invalid fields. Just adding the fields like in this PR made it work properly. I am not sure if you would want to just add those field to the known valid fields, or add some more elaborate checks, but this made the updates work properly (I changed the attachment parent attribute).