### PR TITLE
Fixed stupid prior error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/__pycache__
+Pyzotero.egg-info

--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -358,7 +358,7 @@ class Zotero(object):
         if params.get('content'):
             params['format'] = 'atom'
         # TODO: rewrite format=atom, content=json request
-        if not params.get('limit'):
+        if ('limit' not in params or params['limit'] == 0):
             params['limit'] = 100
         # Need ability to request arbitrary number of results for version response
         elif (params['limit'] == -1 or params['limit'] is None):  # -1 value is hack that works with current version

--- a/test/test_zotero.py
+++ b/test/test_zotero.py
@@ -104,6 +104,26 @@ class ZoteroTests(unittest.TestCase):
             parse_qs('start=7&limit=100&format=json'),
             parse_qs(zot.url_params))
 
+    @httpretty.activate
+    def testRequestBuilderLimitNone(self):
+        """ Should skip limit = 100 param if limit is set to None
+        """
+        zot = z.Zotero('myuserID', 'user', 'myuserkey')
+        zot.add_parameters(limit=None, start=7)
+        self.assertEqual(
+            parse_qs('start=7&format=json'),
+            parse_qs(zot.url_params))
+
+    @httpretty.activate
+    def testRequestBuilderLimitNegativeOne(self):
+        """ Should skip limit = 100 param if limit is set to -1
+        """
+        zot = z.Zotero('myuserID', 'user', 'myuserkey')
+        zot.add_parameters(limit=-1, start=7)
+        self.assertEqual(
+            parse_qs('start=7&format=json'),
+            parse_qs(zot.url_params))
+
     # @httpretty.activate
     # def testBuildQuery(self):
     #     """ Check that spaces etc. are being correctly URL-encoded and added


### PR DESCRIPTION
I made a super embarrassing error in the test for params['limit']=None ……(was foiled by the params.get default) so I fixed this and added two unit tests to make sure it got it right this time.

Basically the first pull request I sent only worked for params['limit']=-1 and not params['limit']=None