### PR TITLE
Update zotero.py

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -902,7 +902,7 @@ class Zotero(object):
             'filename'])
         template = template | set(self.temp_keys)
         for pos, item in enumerate(items):
-            if item.keys() == [u'links', u'library', u'version', u'meta', u'key', u'data']:
+            if set(item) == set([u'links', u'library', u'version', u'meta', u'key', u'data']):
                 # we have an item that was retrieved from the API
                 item = item['data']
             to_check = set(i for i in list(item.keys()))


### PR DESCRIPTION
This change enables compatibility with python3 (which is broken because dict.keys() returns an iterable and not a list in python3). Also using sets instead of lists ensures that the order of the keys does not matter.