### PR TITLE
Correct Zotero.check_items() raised exception name

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -839,7 +839,7 @@ Example:
 
    .. py:method:: Zotero.check_items(items)
 
-        Check whether items to be created on the server contain only valid keys. This method first creates a set of valid keys by calling :py:meth:`item_fields()`, then compares the user-created dicts to it. If any keys in the user-created dicts are unknown, a ``KeyError`` exception is raised, detailing the invalid fields.
+        Check whether items to be created on the server contain only valid keys. This method first creates a set of valid keys by calling :py:meth:`item_fields()`, then compares the user-created dicts to it. If any keys in the user-created dicts are unknown, a ``InvalidItemFields`` exception is raised, detailing the invalid fields.
 
         :param list items: one or more dicts containing item data
         :rtype: List. Each list item is a valid dict containing item data.


### PR DESCRIPTION
Dear maintainer,
The exception raised by Zotero.check_items() is incorrect in the documentation.
Having the good one is needed to handle it properly on code using PyZotero.
Thanks,
Pierre-Alexandre