### PR TITLE
Attachment template type

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -824,11 +824,12 @@ Item Methods
         :param str itemtype: a valid Zotero item type. A list of available item types can be obtained by the use of :py:meth:`item_types()`
         :rtype: list of dicts
 
-    .. py:method:: Zotero.item_template(itemtype)
+    .. py:method:: Zotero.item_template(itemtype, linkmode)
 
         Returns an item creation template for the specified item type
 
         :param str itemtype: a valid Zotero item type. A list of available item types can be obtained by the use of :py:meth:`item_types()`
+        :param str linkmode: either None (default) or a valid Zotero linkMode value required when itemtype is attachment. A list of available link modes can be obtained by the use of :py:meth:`item_attachment_link_modes()`
         :rtype: dict
 
 Creating and Updating Items

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1003,9 +1003,9 @@ Collection Methods
         :rtype: list of dicts
         :rtype: Boolean
 
-    .. py:method:: Zotero.create_collections(dicts[, last_modified])
+    .. py:method:: Zotero.create_collection(dicts[, last_modified])
 
-        Alias for create_collections to preserve backward compatibility
+        Alias for :py:meth:`Zotero.create_collections()` to preserve backward compatibility
 
     .. py:method:: Zotero.addto_collection(collection, item)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -634,14 +634,6 @@ If you wish to retrieve item counts for subsets of a library, you can use the fo
 
     :rtype: int
 
-.. py:method:: Zotero.num_tagitems(tag)
-
-    Returns the count of items for the specified tag
-
-    :rtype: int
-
-.. _parameters:
-
 ================================
 Retrieving last modified version
 ================================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -49,6 +49,8 @@ Installation
 ============
 Using `pip <http://www.pip-installer.org/en/latest/index.html>`_: ``pip install pyzotero``
 
+Using `Anaconda <https://www.anaconda.com/distribution/>`_: ``conda config --add channels conda-forge && conda install pyzotero``
+
 From a local clone, if you wish to install Pyzotero from a specific branch:
 
     .. code-block:: bash

--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -33,7 +33,7 @@ THE SOFTWARE.
 from __future__ import unicode_literals
 
 __author__ = "Stephan Hügel"
-__version__ = "1.4.5"
+__version__ = "1.4.6"
 __api_version__ = "3"
 
 import sys

--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -33,7 +33,7 @@ THE SOFTWARE.
 from __future__ import unicode_literals
 
 __author__ = "Stephan Hügel"
-__version__ = "1.4.4"
+__version__ = "1.4.5"
 __api_version__ = "3"
 
 import sys
@@ -572,14 +572,6 @@ class Zotero(object):
         """
         query = "/{t}/{u}/collections/{c}/items".format(
             u=self.library_id, t=self.library_type, c=collection.upper()
-        )
-        return self._totals(query)
-
-    def num_tagitems(self, tag):
-        """ Return the total number of items for the specified tag
-        """
-        query = "/{t}/{u}/tags/{ta}/items".format(
-            u=self.library_id, t=self.library_type, ta=tag
         )
         return self._totals(query)
 

--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -985,7 +985,7 @@ class Zotero(object):
         return [t["tag"] for t in retrieved]
 
     # The following methods are Write API calls
-    def item_template(self, itemtype):
+    def item_template(self, itemtype, linkmode=None):
         """ Get a template for a new item
         """
         # if we have a template and it hasn't been updated since we stored it
@@ -995,6 +995,14 @@ class Zotero(object):
             query_string, self.templates[template_name], template_name
         ):
             return copy.deepcopy(self.templates[template_name]["tmplt"])
+
+        # Set linkMode parameter for API request if itemtype is attachment
+        if itemtype == "attachment":
+            try:
+                query_string = "{}&linkMode={}".format(query_string, linkmode)
+            except Exception as e:
+                raise error_handler(self, e)
+
         # otherwise perform a normal request and cache the response
         retrieved = self._retrieve_data(query_string)
         return self._cache(retrieved, template_name)

--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -1223,6 +1223,18 @@ class Zotero(object):
         query_string = "/itemFields"
         return query_string, params
 
+    def item_attachment_link_modes(self):
+        """ Get all available link mode types.
+        Note: No viable REST API route was found for this, so I tested and built a list from documentation found
+        here - https://www.zotero.org/support/dev/web_api/json
+        """
+        return [
+            "imported_file",
+            "imported_url",
+            "linked_file",
+            "linked_url"
+        ]
+
     def create_items(self, payload, parentid=None, last_modified=None):
         """
         Create new Zotero items

--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -33,7 +33,7 @@ THE SOFTWARE.
 from __future__ import unicode_literals
 
 __author__ = "Stephan Hügel"
-__version__ = "1.4.3"
+__version__ = "1.4.4"
 __api_version__ = "3"
 
 import sys
@@ -1427,7 +1427,7 @@ class Zotero(object):
                 req.raise_for_status()
             except requests.exceptions.HTTPError:
                 error_handler(self, req)
-            backoff = req.get("backoff")
+            backoff = req.headers.get("backoff")
             if backoff:
                 self._set_backoff(backoff)
             return True
@@ -1457,7 +1457,7 @@ class Zotero(object):
                 req.raise_for_status()
             except requests.exceptions.HTTPError:
                 error_handler(self, req)
-            backoff = req.get("backoff")
+            backoff = req.headers.get("backoff")
             if backoff:
                 self._set_backoff(backoff)
             return True
@@ -1879,10 +1879,10 @@ class Zupload(object):
         try:
             req.raise_for_status()
         except requests.exceptions.HTTPError:
-            error_handler(zinstance, req)
-        backoff = req.get("backoff")
+            error_handler(self.zinstance, req)
+        backoff = req.headers.get("backoff")
         if backoff:
-            zinstance._set_backoff(backoff)
+            self.zinstance._set_backoff(backoff)
         data = req.json()
         for k in data["success"]:
             self.payload[int(k)]["key"] = data["success"][k]

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     install_requires=[
         "feedparser >= 5.1.0",
         "pytz",
-        "requests",
+        "requests >= 2.21.0",
         "pathlib",
         "bibtexparser",
     ],


### PR DESCRIPTION
Fantastic Python package here! My thanks to the contributors for saving me a ton of time this morning. I'm working on a process to link articles in a Zotero library to documents that have been through NLP processing in the [xDD library](https://geodeepdive.org). I found that the item_template function threw an error when I asked for the "attachment" template type, requiring a linkMode parameter. I took a crack at adding this functionality with the commits in this branch and tested it successfully for my use case that you can find in this [Notebook](https://github.com/usgs-bcb/wlci-species/blob/zotero-api-route/workflow/Pull%20References%20via%20Zotero%20API.ipynb).

This might need some additional help from someone on proper use of your error_handler and any insight on pulling available values for linkMode. I found some documentation that I referenced in the index.rst where I pulled together a set of working values, but I did not find a REST API route for this enumeration.