### PR TITLE
Fix arg passing with template function decorator

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -123,11 +123,11 @@ def chunks(l, n):
 def tcache(func):
     """ Take care of the URL building and caching for template functions """
 
-    def wrapped_f(self):
+    def wrapped_f(self, *args, **kwargs):
         """ Calls the decorated function to get query string and params,
         builds URL, retrieves template, caches result, and returns template
         """
-        query_string, params = func(self)
+        query_string, params = func(self, *args, **kwargs)
         r = Request("GET", self.endpoint + query_string, params=params).prepare()
         # now split up the URL
         result = urlparse(r.url)


### PR DESCRIPTION
Calls to `Zotero.item_type_fields()` and `Zotero.item_creator_types()` cause the following error: 

> TypeError: wrapped_f() takes 1 positional argument but 2 were given

The `tcache` decorator fails to pass the required `itemtype` argument.