### PR TITLE
Avoid getting SSL CERTIFICATE_VERIFY_FAILED

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -428,8 +428,9 @@ class Zotero(object):
         self.self_link = request
         # ensure that we wait if there's an active backoff
         self._check_backoff()
+        # include "verify = False" to avoid getting SSL CERTIFICATE_VERIFY_FAILED
         self.request = requests.get(
-            url=full_url, headers=self.default_headers(), params=params
+            url=full_url, headers=self.default_headers(), params=params, verify = False
         )
         self.request.encoding = "utf-8"
         try:


### PR DESCRIPTION
Added parameter to _retrieve_data method in zotero.py to avoid SSL error (see [this comment](https://github.com/urschrei/pyzotero/issues/131#issuecomment-809669559)).