### PR TITLE
Added powerpoint fileformat to prevent that pptx files are interpreted as json and fail retrieval.

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -222,6 +222,7 @@ def retrieve(func):
             "application/msword": "doc",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
             "application/zip": "zip",
             "application/epub+zip": "zip",
             "audio/mpeg": "mp3",


### PR DESCRIPTION
I noticed that when a Zotero item has a powerpoint as an attachment the retrieval using `zot.dump()` or `zot.file()` would fail with the error `*** json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.

Turns out the content type for presentations was not in the format dictionary. I simply added that format, now powerpoint files can be retrieved as well.