### PR TITLE
Fix new_fulltext() ignoring the version parameter. 

### DIFF
--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -642,13 +642,13 @@ class Zotero(object):
             data=json.dumps(payload),
         )
 
-    def new_fulltext(self, version):
+    def new_fulltext(self, since):
         """
         Retrieve list of full-text content items and versions which are newer
-        than <version>
+        than <since>
         """
-        query_string = "/{t}/{u}/fulltext?since={v}".format(
-            t=self.library_type, u=self.library_id, v=version
+        query_string = "/{t}/{u}/fulltext?since={version}".format(
+            t=self.library_type, u=self.library_id, version=since
         )
         headers = self.default_headers()
         self._check_backoff()

--- a/pyzotero/zotero.py
+++ b/pyzotero/zotero.py
@@ -647,11 +647,10 @@ class Zotero(object):
         Retrieve list of full-text content items and versions which are newer
         than <version>
         """
-        query_string = "/{t}/{u}/fulltext".format(
-            t=self.library_type, u=self.library_id
+        query_string = "/{t}/{u}/fulltext?since={v}".format(
+            t=self.library_type, u=self.library_id, v=version
         )
-        headers = {"since": str(version)}
-        headers.update(self.default_headers())
+        headers = self.default_headers()
         self._check_backoff()
         resp = requests.get(self.endpoint + query_string, headers=headers)
         try:


### PR DESCRIPTION
The `new_fulltext()` method was not using the `since=` query string when calling the Zotero API. Thus the `version` specified by the caller was always ignored.

This PR also renames the `version` parameter to `since`. The latter seems more consistent with other Pyzotero method parameters, and with the Zotero API. The [Pyzotero docs](https://pyzotero.readthedocs.io/en/latest/#zotero.Zotero.new_fulltext) also mention `since`, not `version`, although no one using positional parameters would notice.