### PR TITLE
setup.py: do not install the tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=('test*')),
     install_requires=[
         "feedparser > 5.1.0, < 6",
         "pytz",


### PR DESCRIPTION
Minor change to not install the tests to the system, since it is not really required that they are present at runtime for end-users.

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>