### PR TITLE
Document that publications() supports params

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -178,7 +178,7 @@ The following methods will retrieve either user or group items, depending on the
 
         :rtype: list of dicts
 
-    .. py:method:: Zotero.publications()
+    .. py:method:: Zotero.publications([search/request parameters])
 
         Returns the publications from the "My Publications" collection of a user's library. Only available on ``user`` libraries.
 


### PR DESCRIPTION
Thanks for this great library!

I was having an issue with `publications()` (unrelated, figured it out) and went to the documentation to see if I could use pagination on that function, but it didn't seem to be supported. I had to try it anyway just to see, and it turns out it does work. So I thought it might be useful to others in the future to note that in the docs.