### PR TITLE
Enable custom endpoint with extended url path.

### DIFF
--- a/src/pyzotero/zotero.py
+++ b/src/pyzotero/zotero.py
@@ -45,8 +45,10 @@ def build_url(base_url, path, args_dict=None):
     """Build a valid URL so we don't have to worry about string concatenation errors and
     leading / trailing slashes etc"""
     # Returns a list in the structure of urlparse.ParseResult"""
+    if base_url.endswith("/"):
+        base_url = base_url[:-1]
     url_parts = list(urlparse(base_url))
-    url_parts[2] = path
+    url_parts[2] += path
     if args_dict:
         url_parts[4] = urlencode(args_dict)
     return urlunparse(url_parts)

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -59,6 +59,13 @@ class ZoteroTests(unittest.TestCase):
             content_type="application/json",
             body=self.items_doc,
         )
+    
+    def testBuildUrlCorrectHandleEndpoint(self):
+        """url should be concat correctly by build_url"""
+        url = z.build_url("http://localhost:23119/api", "/users/0")
+        self.assertEqual(url, "http://localhost:23119/api/users/0")
+        url = z.build_url("http://localhost:23119/api/", "/users/0")
+        self.assertEqual(url, "http://localhost:23119/api/users/0")
 
     @httpretty.activate
     def testFailWithoutCredentials(self):


### PR DESCRIPTION
Fix the way build_url() create url.

Relate to #191 .

With this fix pyzotero can connect to a local zotero server.

Please refer to [this doc](https://groups.google.com/g/zotero-dev/c/ElvHhIFAXrY/m/fA7SKKwsAgAJ) for the local server feature.

Note that the local server is read-only. Not sure the other functions are working or not, at least we can retrieve something.