### PR TITLE
Use internal transport adapter for file:// URIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "pytz",
     "bibtexparser",
     "httpx>=0.28.1",
-    "httpx-file>=0.2.0",
 ]
 authors = [{ name = "Stephan Hügel", email = "urschrei@gmail.com" }]
 license = {file = "LICENSE.md"}
@@ -37,7 +36,8 @@ test = [
     "pytest >= 7.4.2",
     "httpretty",
     "python-dateutil",
-    "ipython"
+    "ipython",
+    "pytest-asyncio",
 ]
 
 [tool.setuptools.dynamic]
@@ -58,6 +58,8 @@ addopts = [
 testpaths = [
     "tests",
 ]
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.setuptools_scm]
 write_to = "src/_version.py"

--- a/src/pyzotero/filetransport.py
+++ b/src/pyzotero/filetransport.py
@@ -1,0 +1,151 @@
+# This is a modified version of httpx_file:
+# The aiofiles dependency has been removed by modifying the async functionality to use
+# asyncio instead. A specific test for this modification can be found in tests/test_async.py
+# https://github.com/nuno-andre/httpx-file
+
+
+# The license and copyright notice are reproduced below
+# Copyright (c) 2021, Nuno André Novo
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the <copyright holder> nor the names of its contributors
+#   may be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import asyncio
+from pathlib import Path
+from typing import Optional, Tuple
+
+import httpx
+from httpx import (
+    AsyncBaseTransport,
+    BaseTransport,
+    ByteStream,
+    Request,
+    Response,
+)
+from httpx import (
+    AsyncClient as _AsyncClient,
+)
+from httpx import (
+    Client as _Client,
+)
+from httpx._utils import URLPattern
+
+
+# monkey patch to fix httpx URL parsing
+def is_relative_url(self):
+    return not (self._uri_reference.scheme or self._uri_reference.host)
+
+
+def is_absolute_url(self):
+    return not self.is_relative_url
+
+
+httpx.URL.is_relative_url = property(is_relative_url)  # type: ignore
+httpx.URL.is_absolute_url = property(is_absolute_url)  # type: ignore
+
+
+class FileTransport(AsyncBaseTransport, BaseTransport):
+    def _handle(self, request: Request) -> Tuple[Optional[int], httpx.Headers]:
+        if request.url.host and request.url.host != "localhost":
+            raise NotImplementedError("Only local paths are allowed")
+        if request.method in {"PUT", "DELETE"}:
+            status = 501  # Not Implemented
+        elif request.method not in {"GET", "HEAD"}:
+            status = 405  # Method Not Allowed
+        else:
+            status = None
+        return status, request.headers
+
+    def handle_request(self, request: Request) -> Response:
+        status, headers = self._handle(request)
+        stream = None
+        if not status:
+            parts = request.url.path.split("/")
+            if parts[1].endswith((":", "|")):
+                parts[1] = parts[1][:-1] + ":"
+                parts.pop(0)
+            ospath = Path("/".join(parts))
+            try:
+                content = ospath.read_bytes()
+                status = 200
+            except FileNotFoundError:
+                status = 404
+            except PermissionError:
+                status = 403
+            else:
+                stream = ByteStream(content)
+                headers["Content-Length"] = str(len(content))
+        return Response(
+            status_code=status,
+            headers=headers,
+            stream=stream,
+            extensions=dict(),
+        )
+
+    async def handle_async_request(self, request: Request) -> Response:
+        status, headers = self._handle(request)
+        stream = None
+        if not status:
+            parts = request.url.path.split("/")
+            if parts[1].endswith((":", "|")):
+                parts[1] = parts[1][:-1] + ":"
+                parts.pop(0)
+            ospath = Path("/".join(parts))
+            try:
+                loop = asyncio.get_event_loop()
+                content = await loop.run_in_executor(None, ospath.read_bytes)
+                status = 200
+            except FileNotFoundError:
+                status = 404
+            except PermissionError:
+                status = 403
+            else:
+                stream = ByteStream(content)
+                headers["Content-Length"] = str(len(content))
+        return Response(
+            status_code=status,
+            headers=headers,
+            stream=stream,
+            extensions=dict(),
+        )
+
+
+class Client(_Client):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.mount("file://", FileTransport())
+
+    def mount(self, protocol: str, transport: BaseTransport) -> None:
+        self._mounts.update({URLPattern(protocol): transport})
+
+
+class AsyncClient(_AsyncClient):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.mount("file://", FileTransport())
+
+    def mount(self, protocol: str, transport: AsyncBaseTransport) -> None:
+        self._mounts.update({URLPattern(protocol): transport})
+
+
+__all__ = ["FileTransport", "AsyncClient", "Client"]

--- a/src/pyzotero/zotero.py
+++ b/src/pyzotero/zotero.py
@@ -40,11 +40,11 @@ import feedparser
 import httpx
 import pytz
 from httpx import Request
-from httpx_file import Client as File_Client
 
 import pyzotero as pz
 
 from . import zotero_errors as ze
+from .filetransport import Client as File_Client
 
 # Avoid hanging the application if there's no server response
 timeout = 30

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+from pyzotero.filetransport import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_file_transport():
+    test_file = Path("test.txt")
+    test_file.write_text("test content")
+
+    client = AsyncClient()
+    try:
+        async with client:
+            resp = await client.get(f"file:///{test_file.absolute()}")
+            content = await resp.aread()
+            assert resp.status_code == 200
+            assert content == b"test content"
+    finally:
+        test_file.unlink()

--- a/uv.lock
+++ b/uv.lock
@@ -2,15 +2,6 @@ version = 1
 requires-python = ">=3.9"
 
 [[package]]
-name = "aiofiles"
-version = "24.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896 },
-]
-
-[[package]]
 name = "anyio"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -159,19 +150,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
-]
-
-[[package]]
-name = "httpx-file"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiofiles" },
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/f7/737dbfaa3b3288ce69f75fad9a4cd22cae60d71763618ddd849018895172/httpx-file-0.2.0.tar.gz", hash = "sha256:a00f1dd02c9ffb5e7e072205c30f7ae0d867c397318b045a40b3268f2cdfa932", size = 4250 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/9c/4f3fba4c1b5a8919c3f6d407a41df43980c6a03a631d49f458b9546da128/httpx_file-0.2.0-py3-none-any.whl", hash = "sha256:9a425b351bf65aa394c02096204dc3fa8b647573a289079f927d3e3abfa3c7c8", size = 4471 },
 ]
 
 [[package]]
@@ -354,6 +332,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/df/adcc0d60f1053d74717d21d58c0048479e9cab51464ce0d2965b086bd0e2/pytest_asyncio-0.25.2.tar.gz", hash = "sha256:3f8ef9a98f45948ea91a0ed3dc4268b5326c0e7bce73892acc654df4262ad45f", size = 53950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/d8/defa05ae50dcd6019a95527200d3b3980043df5aa445d40cb0ef9f7f98ab/pytest_asyncio-0.25.2-py3-none-any.whl", hash = "sha256:0d0bb693f7b99da304a0634afc0a4b19e49d5e0de2d670f38dc4bfa5727c5075", size = 19400 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -381,7 +371,6 @@ dependencies = [
     { name = "bibtexparser" },
     { name = "feedparser" },
     { name = "httpx" },
-    { name = "httpx-file" },
     { name = "pytz" },
 ]
 
@@ -390,6 +379,7 @@ test = [
     { name = "httpretty" },
     { name = "ipython" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "python-dateutil" },
 ]
 
@@ -399,9 +389,9 @@ requires-dist = [
     { name = "feedparser", specifier = ">=6.0.11" },
     { name = "httpretty", marker = "extra == 'test'" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "httpx-file", specifier = ">=0.2.0" },
     { name = "ipython", marker = "extra == 'test'" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.4.2" },
+    { name = "pytest-asyncio", marker = "extra == 'test'" },
     { name = "python-dateutil", marker = "extra == 'test'" },
     { name = "pytz" },
 ]


### PR DESCRIPTION
Lightly rewrote `httpx_file`'s async client to use asyncio (We don't make async requests in Pyzotero, but who can say what the future holds), removing the dependency on `aiofiles`, which isn't available on conda.