### PR TITLE
Update zotero.py to unpack dicts to avoid operand type error

### DIFF
--- a/src/pyzotero/zotero.py
+++ b/src/pyzotero/zotero.py
@@ -465,7 +465,7 @@ class Zotero:
             params = {}
         if not self.url_params:
             self.url_params = {}
-        merged_params = params | self.url_params
+        merged_params = {**params, **self.url_params}
         # our incoming url might be from the "links" dict, in which case it will contain url parameters.
         # Unfortunately, httpx doesn't like to merge query paramaters in the url string and passed params
         # so we strip the url params, combining them with our existing url_params


### PR DESCRIPTION
Description of changes: merge `self.url_params` and `url_params` dictionaries by unpacking them because current bitwise operation throws a type error (line 468).

e.g., 

```
  File "python3.8/site-packages/pyzotero/zotero.py", line 167, in wrapped_f
    retrieved = self._retrieve_data(func(self, *args))
  File "python3.8/site-packages/pyzotero/zotero.py", line 460, in _retrieve_data
    merged_params = params | self.url_params
TypeError: unsupported operand type(s) for |: 'dict' and 'dict'
Error: Process completed with exit code 1.
```

I checked if there would be any issues with creating a new dictionary instead of merging in place and didn't find anywhere the merged params were being set or used outside of line 472 where they are passed to `merge_params` to generate the `final_params`.

I pulled the code, ran `ruff check`, and ran the test suite (successfully).

Cheers!

Issue reference (if applicable): None

- [X] I have read [the CONTRIBUTING doc](CONTRIBUTING.md)
