### PR TITLE
Replace manual URL building

### DIFF
--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -413,7 +413,7 @@ class ZoteroTests(unittest.TestCase):
         zot.tags()
         self.assertEqual(zot.links["next"], "/users/436/items/top?limit=1&start=1")
         self.assertEqual(zot.links["last"], "/users/436/items/top?limit=1&start=2319")
-        self.assertEqual(zot.links["alternate"], "/users/436/items/top?")
+        self.assertEqual(zot.links["alternate"], "/users/436/items/top")
 
     @httpretty.activate
     def testParseLinkHeadersPreservesAllParameters(self):


### PR DESCRIPTION
Replaces f-string concatenation with urlunparse() for consistency. This also fixes a bug where URLs without query parameters incorrectly had a trailing '?' appended.

Also refactors build_url function

<!-- Thanks for opening a PR. Please read the following:

- **Base your changes on the `main` branch**
    - If necessary, rebase against `main` before opening a pull request
- This codebase uses Ruff. PRs that reformat code will not be accepted.
- Ensure that all methods added have a proper docstring. **Please do not use Doctest**
- If at all possible, don't add dependencies
    - If it is unavoidable, you must ensure that the dependency is maintained, and supported
    - Ensure that you add your dependency to [pyproject.toml](pyproject.toml)
- Run the tests and ensure that they pass. If you are adding a feature **you must add tests that exercise it**
- If your pull request is a feature **document the feature**
- One feature per pull request
- [squash](http://git-scm.com/book/en/Git-Tools-Rewriting-History#Squashing-Commits) your commits before opening a pull request unless it makes no sense to do so
- If in doubt, comment your code.

## License of Contributed Code
Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be licensed under the Blue Oak Model License 1.0, without any additional terms or conditions.  
Please note that pull requests with licenses that are more restrictive than or otherwise incompatible with the license will not be accepted. -->

