### PR TITLE
Fix fulltext search to include parent items of matching attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ pyzotero listcollections
 pyzotero itemtypes
 ```
 
+## Search Behaviour
+
+By default, `pyzotero search` searches only top-level item titles and metadata fields.
+
+When the `--fulltext` flag is used, the search expands to include all full-text indexed content, including PDFs and other attachments. Since most full-text content comes from PDF attachments rather than top-level items, the CLI automatically retrieves the parent bibliographic items for any matching attachments. This ensures you receive useful bibliographic records (journal articles, books, etc.) rather than raw attachment items.
+
 ## Output Format
 
 By default, the CLI outputs human-readable text with a subset of metadata including:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -152,6 +152,13 @@ List available item types:
 
         pyzotero itemtypes
 
+Search Behaviour
+----------------
+
+By default, ``pyzotero search`` searches only top-level item titles and metadata fields.
+
+When the ``--fulltext`` flag is used, the search expands to include all full-text indexed content, including PDFs and other attachments. Since most full-text content comes from PDF attachments rather than top-level items, the CLI automatically retrieves the parent bibliographic items for any matching attachments. This ensures you receive useful bibliographic records (journal articles, books, etc.) rather than raw attachment items.
+
 Output Format
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyzotero"
-version = "1.7.0"
+version = "1.7.1"
 description = "Python wrapper for the Zotero API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -784,7 +784,7 @@ wheels = [
 
 [[package]]
 name = "pyzotero"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "bibtexparser" },


### PR DESCRIPTION
When --fulltext is enabled, the search now uses items() or collection_items()  instead of top() or collection_items_top(). This returns both top-level items  and attachments that match the search.

Since most full-text indexed content comes from PDF attachments, we then:
1. Separate results into top-level and attachment items
2. Extract unique parent IDs from attachments
3. Batch retrieve parent items using get_subset() (50 items at a time)
4. Combine and deduplicate results by item key

This ensures that when a PDF matches a full-text search, we return the parent  bibliographic item rather than just the attachment.

<!-- Thanks for opening a PR. Please read the following:

- **Base your changes on the `main` branch**
    - If necessary, rebase against `main` before opening a pull request
- This codebase uses Ruff. PRs that reformat code will not be accepted.
- Ensure that all methods added have a proper docstring. **Please do not use Doctest**
- If at all possible, don't add dependencies
    - If it is unavoidable, you must ensure that the dependency is maintained, and supported
    - Ensure that you add your dependency to [pyproject.toml](pyproject.toml)
- Run the tests and ensure that they pass. If you are adding a feature **you must add tests that exercise it**
- If your pull request is a feature **document the feature**
- One feature per pull request
- [squash](http://git-scm.com/book/en/Git-Tools-Rewriting-History#Squashing-Commits) your commits before opening a pull request unless it makes no sense to do so
- If in doubt, comment your code.

## License of Contributed Code
Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be licensed under the Blue Oak Model License 1.0, without any additional terms or conditions.  
Please note that pull requests with licenses that are more restrictive than or otherwise incompatible with the license will not be accepted. -->

Description of changes:
Issue reference (if applicable):

- [ ] I have read [the CONTRIBUTING doc](CONTRIBUTING.md)
