### PR TITLE
README.md: add note about enabling local API

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Use the `--json` flag to output structured JSON.
 
 ## Optional: Command-Line Interface
 
-Pyzotero includes an optional command-line interface for searching and querying your local Zotero library.
+Pyzotero includes an optional command-line interface for searching and querying your local Zotero library. As it uses the local API server introduced in Zotero 7, it requires "Allow other applications on this computer to communicate with Zotero" to be enabled in Zotero's Settings > Advanced.
 
 ### Installing the CLI
 


### PR DESCRIPTION
Description of changes:

Adds a line to the CLI installation instructions to note that the local API server has to be enabled for it to work. I had it disabled, and spent ten very confused minutes trying to figure out what wasn't working, so hopefully this helps someone else.

Issue reference (if applicable): N/A

- [x] I have read [the CONTRIBUTING doc](CONTRIBUTING.md)
