### PR TITLE
create_items: set parentItem in POST payload instead of separate PATCH requests

### DIFF
--- a/src/pyzotero/_client.py
+++ b/src/pyzotero/_client.py
@@ -1086,6 +1086,9 @@ class Zotero:
         if last_modified is not None:
             headers["If-Unmodified-Since-Version"] = str(last_modified)
         to_send = list(self._cleanup(*payload, allow=("key")))
+        if parentid:
+            for item in to_send:
+                item["parentItem"] = parentid
         self._check_backoff()
         req = self.client.post(
             url=build_url(
@@ -1104,31 +1107,6 @@ class Zotero:
         backoff = get_backoff_duration(self.request.headers)
         if backoff:
             self._set_backoff(backoff)
-        if parentid:
-            # we need to create child items using PATCH
-            # TODO: handle possibility of item creation + failed parent attachment
-            uheaders = {
-                "If-Unmodified-Since-Version": req.headers["last-modified-version"],
-            }
-            for value in resp["success"].values():
-                child_payload: dict[str, str] = {"parentItem": parentid}
-                self._check_backoff()
-                presp = self.client.patch(
-                    url=build_url(
-                        self.endpoint,
-                        f"/{self.library_type}/{self.library_id}/items/{value}",
-                    ),
-                    json=child_payload,
-                    headers=dict(uheaders),
-                )
-                self.request = presp
-                try:
-                    presp.raise_for_status()
-                except httpx.HTTPError as exc:
-                    error_handler(self, presp, exc)
-                backoff = get_backoff_duration(presp.headers)
-                if backoff:
-                    self._set_backoff(backoff)
         return resp
 
     def create_collection(

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -715,6 +715,26 @@ class ZoteroTests(unittest.TestCase):
         request = mock.last_request()
         self.assertFalse("If-Unmodified-Since-Version" in request.headers)
 
+    def testItemCreationWithParentId(self):
+        """Checks that parentItem is set in the POST payload when parentid is given"""
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+        mock.register(
+            "POST",
+            "https://api.zotero.org/users/myuserID/items",
+            body=self.creation_doc,
+            content_type="application/json",
+            status=200,
+        )
+        note = {"itemType": "note", "note": "A test note", "tags": []}
+        resp = zot.create_items([note], parentid="PARENT123")
+        self.assertEqual("ABC123", resp["success"]["0"])
+        request = mock.last_request()
+        request_body = json.loads(request.body.decode("utf-8"))
+        self.assertEqual(request_body[0]["parentItem"], "PARENT123")
+        # Should be a single POST, no PATCH requests
+        self.assertEqual(len(mock.latest_requests()), 1)
+
     def testItemCreationLastModified(self):
         """Checks 'If-Unmodified-Since-Version' header correctly set on create_items"""
         mock = MockClient()


### PR DESCRIPTION
<!-- Thanks for opening a PR. Please read the following:

- **Base your changes on the `main` branch**
    - If necessary, rebase against `main` before opening a pull request
- This codebase uses Ruff. PRs that reformat code will not be accepted.
- Ensure that all methods added have a proper docstring. **Please do not use Doctest**
- If at all possible, don't add dependencies
    - If it is unavoidable, you must ensure that the dependency is maintained, and supported
    - Ensure that you add your dependency to [pyproject.toml](pyproject.toml)
- Run the tests and ensure that they pass. If you are adding a feature **you must add tests that exercise it**
- If your pull request is a feature **document the feature**
- One feature per pull request
- [squash](http://git-scm.com/book/en/Git-Tools-Rewriting-History#Squashing-Commits) your commits before opening a pull request unless it makes no sense to do so
- If in doubt, comment your code.

## License of Contributed Code
Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be licensed under the Blue Oak Model License 1.0, without any additional terms or conditions.  
Please note that pull requests with licenses that are more restrictive than or otherwise incompatible with the license will not be accepted. -->

Description of changes:
Issue reference (if applicable):

- [ ] I have read [the CONTRIBUTING doc](CONTRIBUTING.md)
