### PR TITLE
Add configurable upload_timeout to fix WriteTimeout on large files

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -255,7 +255,7 @@ General Usage
 First, create a new Zotero instance:
 
 
-    .. py:class:: Zotero(library_id, library_type[, api_key, preserve_json_order, locale, local])
+    .. py:class:: Zotero(library_id, library_type[, api_key, preserve_json_order, locale, local, upload_timeout])
 
         :param str library_id: a valid Zotero API user ID
         :param str library_type: a valid Zotero API library type: **user** or **group**
@@ -263,6 +263,7 @@ First, create a new Zotero instance:
         :param bool preserve_json_order: Load JSON returns with OrderedDict to preserve their order
         :param str locale: Set the `locale <https://www.zotero.org/support/dev/web_api/v3/types_and_fields#zotero_web_api_item_typefield_requests>`_, allowing retrieval of localised item types, field types, and creator types. Defaults to "en-US".
         :param str local: use the local Zotero http server instead of the remote API. Note that the local server currently (November 2024) only allows **read** requests
+        :param int/float upload_timeout: timeout in seconds for file uploads to storage (default: 120). Increase this for very large files or slow connections.
 
 
 Example:

--- a/src/pyzotero/_client.py
+++ b/src/pyzotero/_client.py
@@ -70,6 +70,7 @@ class Zotero:
         locale: str = "en-US",
         local: bool = False,
         client: httpx.Client | None = None,
+        upload_timeout: int | float = 120,
     ) -> None:
         self.client: httpx.Client | None = None
         """Store Zotero credentials"""
@@ -102,6 +103,7 @@ class Zotero:
         self.tag_data = False
         self.request: httpx.Response | None = None
         self.snapshot = False
+        self.upload_timeout = upload_timeout
         self.client = client or httpx.Client(
             headers=self.default_headers(),
             follow_redirects=True,

--- a/src/pyzotero/_upload.py
+++ b/src/pyzotero/_upload.py
@@ -177,9 +177,13 @@ class Zupload:
                 url=authdata["url"],
                 files=upload_pairs,
                 headers={"User-Agent": f"Pyzotero/{pz.__version__}"},
+                timeout=self.zinstance.upload_timeout,
             )
         except httpx.ConnectError:
             msg = "ConnectionError"
+            raise ze.UploadError(msg) from None
+        except httpx.TimeoutException:
+            msg = "Upload timed out. Try increasing upload_timeout when creating the Zotero instance."
             raise ze.UploadError(msg) from None
         try:
             upload.raise_for_status()


### PR DESCRIPTION
Fixes #303.

The bare httpx.post() call for S3 uploads had no timeout, inheriting httpx's 5s default. Large files (> 7MB) would fail with WriteTimeout. Added `upload_timeout` parameter (default 120s) to `Zotero.__init__()` which is passed through to the upload call.

<!-- Thanks for opening a PR. Please read the following:

- **Base your changes on the `main` branch**
    - If necessary, rebase against `main` before opening a pull request
- This codebase uses Ruff. PRs that reformat code will not be accepted.
- Ensure that all methods added have a proper docstring. **Please do not use Doctest**
- If at all possible, don't add dependencies
    - If it is unavoidable, you must ensure that the dependency is maintained, and supported
    - Ensure that you add your dependency to [pyproject.toml](pyproject.toml)
- Run the tests and ensure that they pass. If you are adding a feature **you must add tests that exercise it**
- If your pull request is a feature **document the feature**
- One feature per pull request
- [squash](http://git-scm.com/book/en/Git-Tools-Rewriting-History#Squashing-Commits) your commits before opening a pull request unless it makes no sense to do so
- If in doubt, comment your code.

## License of Contributed Code
Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be licensed under the Blue Oak Model License 1.0, without any additional terms or conditions.  
Please note that pull requests with licenses that are more restrictive than or otherwise incompatible with the license will not be accepted. -->

Description of changes:
Issue reference (if applicable):

- [x] I have read [the CONTRIBUTING doc](CONTRIBUTING.md)
