### PR TITLE
Send If-Match at register-upload step for existing files (#322)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyzotero"
-version = "1.13.0"
+version = "1.13.1"
 description = "Python wrapper for the Zotero API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pyzotero/_upload.py
+++ b/src/pyzotero/_upload.py
@@ -149,13 +149,17 @@ class Zupload:
         return auth_req.json()
 
     def _upload_file(
-        self, authdata: dict[str, Any], attachment: str, reg_key: str
+        self,
+        authdata: dict[str, Any],
+        attachment: str,
+        reg_key: str,
+        md5: str | None = None,
     ) -> None:
         """Step 2: auth successful, and file not on server.
 
         See zotero.org/support/dev/server_api/file_upload#a_full_upload
 
-        reg_key isn't used, but we need to pass it through to Step 3.
+        reg_key and md5 aren't used here, but we pass them through to Step 3.
         """
         upload_dict = authdata["params"]
         # pass tuple of tuples (not dict!), to ensure key comes first
@@ -182,14 +186,22 @@ class Zupload:
             raise ze.UploadError(msg) from None
         self._check_response(upload)
         # now check the responses
-        return self._register_upload(authdata, reg_key)
+        return self._register_upload(authdata, reg_key, md5=md5)
 
-    def _register_upload(self, authdata: dict[str, Any], reg_key: str) -> None:
-        """Step 3: upload successful, so register it."""
-        reg_headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "If-None-Match": "*",
-        }
+    def _register_upload(
+        self, authdata: dict[str, Any], reg_key: str, md5: str | None = None
+    ) -> None:
+        """Step 3: upload successful, so register it.
+
+        For a new file we send ``If-None-Match: *``; when replacing an existing
+        file's contents we must instead send ``If-Match: <previous md5>``, matching
+        the header used in Step 1. The Zotero API returns 412 otherwise (see #322).
+        """
+        reg_headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        if md5:
+            reg_headers["If-Match"] = md5
+        else:
+            reg_headers["If-None-Match"] = "*"
         reg_data = {"upload": authdata.get("uploadKey")}
         self.zinstance._check_backoff()
         upload_reg = self.zinstance.client.post(
@@ -221,7 +233,7 @@ class Zupload:
             if authdata.get("exists"):
                 result["unchanged"].append(item)
                 continue
-            self._upload_file(authdata, attach, item["key"])
+            self._upload_file(authdata, attach, item["key"], md5=item.get("md5", None))
             result["success"].append(item)
         return result
 

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -13,6 +13,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlencode, urlparse
 
+import httpx
 import pytz
 import whenever
 from dateutil import parser
@@ -1379,6 +1380,96 @@ class ZoteroTests(unittest.TestCase):
 
         # Clean up
         os.remove(temp_file_path)
+
+    def _run_register_upload(self, payload):
+        """Drive Zupload.upload through to the register step and return that request.
+
+        _get_auth is mocked to return valid auth data and the storage (S3) POST
+        is stubbed, so the only request reaching the items/<key>/file endpoint is
+        the Step 3 register-upload call whose headers we want to inspect.
+        """
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+
+        temp_file_path = os.path.join(self.cwd, "api_responses", "test_upload_file.txt")
+        with open(temp_file_path, "w") as f:
+            f.write("Test file content for upload")
+
+        mock_auth_data = {
+            "url": "https://uploads.zotero.org/",
+            "params": {
+                "key": "abcdef1234567890",
+                "prefix": "prefix",
+                "suffix": "suffix",
+            },
+            "uploadKey": "upload_key_123",
+        }
+
+        # Step 3: register upload endpoint
+        mock.register(
+            "POST",
+            "https://api.zotero.org/users/myuserID/items/EXISTINGKEY/file",
+            content_type="application/json",
+            body=json.dumps({}),
+            status=200,
+        )
+
+        try:
+            with (
+                patch.object(z.Zupload, "_verify", return_value=None),
+                patch.object(z.Zupload, "_get_auth", return_value=mock_auth_data),
+                patch(
+                    "httpx.post",
+                    return_value=httpx.Response(
+                        201,
+                        request=httpx.Request("POST", "https://uploads.zotero.org/"),
+                    ),
+                ),
+            ):
+                upload = z.Zupload(
+                    zot, payload, basedir=os.path.join(self.cwd, "api_responses")
+                )
+                upload.upload()
+        finally:
+            os.remove(temp_file_path)
+
+        # The register request is the one carrying the uploadKey in its body
+        for req in mock.latest_requests():
+            if req.url.endswith("/items/EXISTINGKEY/file") and b"upload" in req.body:
+                return req
+        return None
+
+    def testFileUpdateRegisterUsesIfMatch(self):
+        """Updating an existing file must send If-Match at the register step (#322)."""
+        existing_md5 = "0123456789abcdef0123456789abcdef"
+        payload = [
+            {
+                "key": "EXISTINGKEY",
+                "filename": "test_upload_file.txt",
+                "title": "Test File",
+                "linkMode": "imported_file",
+                "md5": existing_md5,
+            }
+        ]
+        register_request = self._run_register_upload(payload)
+        self.assertIsNotNone(register_request, "No register-upload request was made")
+        self.assertEqual(register_request.headers.get("If-Match"), existing_md5)
+        self.assertNotIn("If-None-Match", register_request.headers)
+
+    def testFileUploadRegisterUsesIfNoneMatch(self):
+        """Uploading a new file must send If-None-Match: * at the register step."""
+        payload = [
+            {
+                "key": "EXISTINGKEY",
+                "filename": "test_upload_file.txt",
+                "title": "Test File",
+                "linkMode": "imported_file",
+            }
+        ]
+        register_request = self._run_register_upload(payload)
+        self.assertIsNotNone(register_request, "No register-upload request was made")
+        self.assertEqual(register_request.headers.get("If-None-Match"), "*")
+        self.assertNotIn("If-Match", register_request.headers)
 
     def testFileUploadInvalidPayload(self):
         """Tests file upload process with invalid payload mixing items with and without keys"""

--- a/uv.lock
+++ b/uv.lock
@@ -1287,7 +1287,7 @@ wheels = [
 
 [[package]]
 name = "pyzotero"
-version = "1.13.0"
+version = "1.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "bibtexparser" },


### PR DESCRIPTION
Fixes #322.

## Problem

When `upload_attachments()` is used to replace the contents of an existing attachment (payload carries the attachment `key` and the currently stored file's `md5`), the upload fails with HTTP 412 (`If-None-Match: * set but file exists`).

`_get_auth` (Step 1) correctly branches on `md5` — sending `If-Match: <md5>` for an existing file — but `_register_upload` (Step 3) hardcoded `If-None-Match: *` regardless, so the register call always used new-file semantics.

## Fix

Thread the payload `md5` (the same value already passed to `_get_auth`) through `_upload_file` to `_register_upload`, and branch on it:

- existing file → `If-Match: <previous md5>`
- new file → `If-None-Match: *`

This matches the [Zotero file upload API](https://www.zotero.org/support/dev/web_api/v3/file_upload), which requires Step 3 to send the same `If-Match`/`If-None-Match` header as Step 1.

## Tests

Two tests drive `Zupload.upload()` through to the register step and assert the headers on the register request:

- `testFileUpdateRegisterUsesIfMatch` — update path sends `If-Match: <md5>` and no `If-None-Match` (fails on the old code; reproduces the 412 condition).
- `testFileUploadRegisterUsesIfNoneMatch` — new-file path still sends `If-None-Match: *`.

No public API change. `ruff format`/`ruff check` clean; full `test_zotero.py` suite passes.