### PR TITLE
Set `Content-Type: application/json` on `update_item` and `create_collections`

### DIFF
--- a/src/pyzotero/_client.py
+++ b/src/pyzotero/_client.py
@@ -1127,7 +1127,7 @@ class Zotero:
                 f"/{self.library_type}/{self.library_id}/collections",
             ),
             headers=headers,
-            content=json.dumps(payload),
+            json=payload,
         )
         self.request = req
         self._post_check(req)
@@ -1213,7 +1213,7 @@ class Zotero:
                 f"/{self.library_type}/{self.library_id}/items/{ident}",
             ),
             headers=headers,
-            content=json.dumps(to_send),
+            json=to_send,
         )
 
     def _batch_update(self, payload: list[dict[str, Any]], collection: str) -> bool:

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -623,6 +623,7 @@ class ZoteroTests(unittest.TestCase):
         self.assertTrue("ABC123", resp["success"]["0"])
         request = mock.last_request()
         self.assertFalse("If-Unmodified-Since-Version" in request.headers)
+        self.assertEqual(request.headers["Content-Type"], "application/json")
 
     def testCollectionCreationLastModified(self):
         """Tests creation of a new collection with last_modified param"""
@@ -813,6 +814,7 @@ class ZoteroTests(unittest.TestCase):
         self.assertEqual(resp, True)
         request = mock.last_request()
         self.assertEqual(request.headers["If-Unmodified-Since-Version"], "3")
+        self.assertEqual(request.headers["Content-Type"], "application/json")
 
     def testItemUpdateLastModified(self):
         """Tests item update using update_item with last_modified parameter"""


### PR DESCRIPTION
create_items/update_collection already set this header, which is required per RFC 9110. api.zotero.org currently tolerates its absence, but the Zotero client's local API requires it and otherwise reads an empty body.

- [X] I have read [the CONTRIBUTING doc](CONTRIBUTING.md)
