### PR TITLE
Add OAuth 1.0a helper for obtaining a Zotero API key

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         cache-dependency-glob: "**/pyproject.toml"
 
     - name: Install the project and deps
-      run: uv sync --dev --locked
+      run: uv sync --dev --extra cli --extra oauth --extra mcp --locked
 
     - name: Run tests
       run: uv run pytest --junit-xml=junit.xml

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ for item in items:
     print(f"Item: {item['data']['itemType']} | Key: {item['data']['key']}")
 ```
 
+Instead of creating an API key by hand, an application can obtain one on a user's behalf using Zotero's OAuth flow. Install the optional `oauth` extra (`pip install "pyzotero[oauth]"`) and see the [OAuth documentation](http://pyzotero.readthedocs.org/en/latest/#oauth-authentication), or run `pyzotero auth`.
+
 # Documentation
 
 Full documentation of available Pyzotero methods, code examples, and sample output is available on [Read The Docs][3].

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -70,6 +70,16 @@ If you just want to use the CLI without permanently installing Pyzotero:
 
 See :ref:`cli-usage` for usage details.
 
+Optional: OAuth
+~~~~~~~~~~~~~~~
+
+Pyzotero can obtain an API key on a user's behalf using Zotero's OAuth flow. This requires the optional ``oauth`` extra:
+
+* Using `uv <https://docs.astral.sh/uv/>`_: ``uv add "pyzotero[oauth]"``
+* Using `pip <http://www.pip-installer.org/en/latest/index.html>`_: ``pip install "pyzotero[oauth]"``
+
+See :ref:`oauth` for usage details.
+
 From a local clone, if you wish to install Pyzotero from a specific branch:
 
     .. code-block:: bash
@@ -283,6 +293,65 @@ Example:
 Errors
 ------
 Where possible, any ``ZoteroError`` which is raised will preserve the underlying error in its ``__cause__`` and ``__context__`` properties, should you wish to work with these directly.
+
+
+.. _oauth:
+
+====================
+OAuth authentication
+====================
+
+Instead of asking a user to create an API key by hand, an application can obtain one on their behalf using Zotero's `OAuth 1.0a <https://www.zotero.org/support/dev/web_api/v3/oauth>`_ flow. The flow's product is an ordinary Zotero API key plus the user's numeric ID; once obtained, the key is used exactly as a manually-created one would be. This requires the optional ``oauth`` extra (see :ref:`installation <cli-usage>` above for installation, using the ``oauth`` extra in place of ``cli``).
+
+Before using OAuth you must register an application at `https://www.zotero.org/oauth/apps <https://www.zotero.org/oauth/apps>`_ to obtain a **client key** and **client secret** (the OAuth consumer credentials). These are distinct from the API key the flow produces.
+
+The flow has three legs: fetch a request token, send the user to an authorisation URL to approve the requested permissions, then exchange the approved token plus a verifier for the API key.
+
+    .. py:class:: ZoteroOAuth(client_key, client_secret[, callback])
+
+        :param str client_key: the application's OAuth client (consumer) key
+        :param str client_secret: the application's OAuth client (consumer) secret
+        :param str callback: the OAuth callback. Defaults to ``"oob"`` (out-of-band), in which Zotero displays a verifier code for the user to copy. Web applications should pass a registered redirect URL instead.
+
+    .. py:method:: ZoteroOAuth.authorize_url([library_access, write_access, notes_access, all_groups, identity])
+
+        Fetch a request token and return the URL to send the user to. The boolean flags map to Zotero's permission parameters (``library_access`` defaults to ``True``; ``write_access`` and ``notes_access`` default to ``False``). ``all_groups`` sets the access level for current and future groups and must be one of ``"none"``, ``"read"`` (default) or ``"write"``. Setting ``identity`` requests the user's identity only, without creating a key. The request token is stored on the instance and is also available via the ``request_token`` property.
+
+    .. py:method:: ZoteroOAuth.complete(verifier[, request_token])
+
+        Exchange the approved request token for an API key, returning a ``ZoteroCredentials``. ``verifier`` is the code Zotero returns after the user approves the application. ``request_token`` is optional when the same instance performed :py:meth:`ZoteroOAuth.authorize_url`; supply it when the access leg runs in a separate process (e.g. a web request handler).
+
+    .. py:method:: ZoteroOAuth.complete_from_url(authorization_response[, request_token])
+
+        Convenience for web applications: extract the ``oauth_verifier`` query parameter from the URL Zotero redirected the user to, then delegate to :py:meth:`ZoteroOAuth.complete`.
+
+    .. py:class:: ZoteroCredentials
+
+        Returned by a completed handshake. Has ``api_key``, ``userid`` and ``username`` attributes, and a ``client(**kwargs)`` method returning a :py:class:`Zotero` instance configured with the obtained credentials (any keyword arguments are forwarded to the ``Zotero`` constructor).
+
+A failed handshake raises :py:exc:`OAuthError`.
+
+Example:
+
+    .. code-block:: python
+
+        from pyzotero.oauth import ZoteroOAuth
+
+        oauth = ZoteroOAuth(client_key, client_secret)
+        url = oauth.authorize_url(write_access=True)
+        # send the user to ``url``; they approve and receive a verifier code
+        creds = oauth.complete(verifier)
+        print(creds.userid, creds.api_key)
+        zot = creds.client()  # a ready-to-use Zotero instance
+
+From the command line
+---------------------
+
+With the ``cli`` and ``oauth`` extras installed, the ``pyzotero auth`` command runs the flow interactively: it prints (and can open) the authorisation URL, prompts for the verifier code, then prints the resulting library ID and API key. The client credentials are read from ``--client-key``/``--client-secret`` or the ``ZOTERO_CLIENT_KEY``/``ZOTERO_CLIENT_SECRET`` environment variables.
+
+    .. code-block:: bash
+
+        pyzotero auth --client-key YOUR_KEY --client-secret YOUR_SECRET --write --open
 
 
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ documentation = "https://pyzotero.readthedocs.org"
 [project.optional-dependencies]
 cli = ["click>=8.0.0"]
 mcp = ["mcp[cli]>=1.0.0; python_version>='3.10'"]
+oauth = [
+    "authlib>=1.7.2",
+]
 
 [project.scripts]
 pyzotero = "pyzotero.cli:main"

--- a/src/pyzotero/__init__.py
+++ b/src/pyzotero/__init__.py
@@ -26,6 +26,7 @@ from pyzotero.errors import (
     HTTPError,
     InvalidItemFieldsError,
     MissingCredentialsError,
+    OAuthError,
     ParamNotPassedError,
     PreConditionFailedError,
     PreConditionRequiredError,
@@ -39,6 +40,7 @@ from pyzotero.errors import (
     UploadError,
     UserNotAuthorisedError,
 )
+from pyzotero.oauth import ZoteroCredentials, ZoteroOAuth
 
 __all__ = [
     # Exceptions
@@ -49,6 +51,7 @@ __all__ = [
     "HTTPError",
     "InvalidItemFieldsError",
     "MissingCredentialsError",
+    "OAuthError",
     "ParamNotPassedError",
     "PreConditionFailedError",
     "PreConditionRequiredError",
@@ -64,6 +67,8 @@ __all__ = [
     "UserNotAuthorisedError",
     # Main classes
     "Zotero",
+    "ZoteroCredentials",
+    "ZoteroOAuth",
     "Zupload",
     # Version
     "__version__",

--- a/src/pyzotero/cli.py
+++ b/src/pyzotero/cli.py
@@ -1071,5 +1071,87 @@ def s2search(
     )
 
 
+@main.command()
+@click.option(
+    "--client-key",
+    envvar="ZOTERO_CLIENT_KEY",
+    required=True,
+    help="OAuth client (consumer) key, or set ZOTERO_CLIENT_KEY.",
+)
+@click.option(
+    "--client-secret",
+    envvar="ZOTERO_CLIENT_SECRET",
+    required=True,
+    help="OAuth client (consumer) secret, or set ZOTERO_CLIENT_SECRET.",
+)
+@click.option(
+    "--write",
+    is_flag=True,
+    help="Request write access to the personal library.",
+)
+@click.option(
+    "--notes",
+    is_flag=True,
+    help="Request read access to notes.",
+)
+@click.option(
+    "--no-library",
+    is_flag=True,
+    help="Do not request read access to the personal library.",
+)
+@click.option(
+    "--groups",
+    type=click.Choice(["none", "read", "write"]),
+    default="read",
+    show_default=True,
+    help="Access level for current and future groups.",
+)
+@click.option(
+    "--open",
+    "open_browser",
+    is_flag=True,
+    help="Open the authorisation URL in a browser automatically.",
+)
+@cli_error_handler
+def auth(
+    client_key: str,
+    client_secret: str,
+    write: bool,
+    notes: bool,
+    no_library: bool,
+    groups: str,
+    open_browser: bool,
+) -> None:
+    """Obtain a Zotero API key via OAuth.
+
+    Runs Zotero's OAuth handshake: prints an authorisation URL, waits for the
+    verifier code Zotero shows after you approve the application, then prints
+    the resulting library ID and API key.
+
+    Register an application at https://www.zotero.org/oauth/apps to obtain the
+    client key and secret. Requires the 'oauth' extra (pip install
+    pyzotero[oauth]).
+    """
+    from pyzotero.oauth import ZoteroOAuth  # noqa: PLC0415 - optional dependency
+
+    oauth = ZoteroOAuth(client_key, client_secret)
+    url = oauth.authorize_url(
+        library_access=not no_library,
+        write_access=write,
+        notes_access=notes,
+        all_groups=groups,
+    )
+    click.echo("Authorise this application by visiting:\n", err=True)
+    click.echo(url, err=True)
+    if open_browser:
+        click.launch(url)
+    verifier = click.prompt("\nEnter the verifier code shown by Zotero")
+    creds = oauth.complete(verifier)
+    click.echo("\nAuthorisation successful.")
+    click.echo(f"library_id: {creds.userid}")
+    click.echo(f"api_key:    {creds.api_key}")
+    click.echo(f'\nUse it with: Zotero("{creds.userid}", "user", "{creds.api_key}")')
+
+
 if __name__ == "__main__":
     main()

--- a/src/pyzotero/errors.py
+++ b/src/pyzotero/errors.py
@@ -100,6 +100,14 @@ class UploadError(PyZoteroError):
     """
 
 
+class OAuthError(PyZoteroError):
+    """Raised when the OAuth handshake used to obtain an API key fails.
+
+    Wraps the underlying authlib/transport failure so callers only need to
+    catch a single Pyzotero exception type.
+    """
+
+
 # Mapping of HTTP status codes to exception classes
 ERROR_CODES: dict[int, type[PyZoteroError]] = {
     400: UnsupportedParamsError,

--- a/src/pyzotero/oauth.py
+++ b/src/pyzotero/oauth.py
@@ -1,0 +1,250 @@
+"""OAuth 1.0a helper for obtaining a Zotero API key.
+
+Zotero implements OAuth 1.0a as a way to provision an API key on a user's
+behalf, so that an application does not have to ask the user to create a key by
+hand. The handshake's only product is a normal Zotero API key plus the user's
+numeric ID: the ``oauth_token`` returned by the access step *is* the API key.
+Once obtained, the key is used exactly as a manually-created one would be.
+
+The flow has three legs:
+
+1. Fetch a temporary request token (signed with the application's client key
+   and secret).
+2. Send the user to the authorisation URL to approve the requested permissions.
+3. Exchange the approved request token and a verifier for the access token,
+   which carries the API key and user ID.
+
+To use this module an application must first be registered at
+https://www.zotero.org/oauth/apps to obtain a *client key* and *client secret*
+(the OAuth consumer credentials). These are distinct from the API key the flow
+produces.
+
+OAuth support requires the optional ``oauth`` extra::
+
+    pip install pyzotero[oauth]
+
+Example::
+
+    from pyzotero.oauth import ZoteroOAuth
+
+    oauth = ZoteroOAuth(client_key, client_secret)
+    url = oauth.authorize_url(write_access=True)
+    # send the user to ``url``; they approve and receive a verifier code
+    creds = oauth.complete(verifier)
+    zot = creds.client()
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+
+from .errors import OAuthError
+
+if TYPE_CHECKING:
+    from ._client import Zotero
+
+# Authlib failures plus transport-level errors are wrapped as OAuthError.
+try:
+    from authlib.integrations.httpx_client import OAuth1Client
+    from authlib.integrations.httpx_client import OAuthError as _AuthlibOAuthError
+
+    _OAUTH_FAILURES: tuple[type[BaseException], ...] = (
+        httpx.HTTPError,
+        _AuthlibOAuthError,
+    )
+except ImportError:  # pragma: no cover - exercised only without the extra
+    OAuth1Client = None  # ty: ignore[invalid-assignment]
+    _OAUTH_FAILURES = (httpx.HTTPError,)
+
+REQUEST_TOKEN_URL = "https://www.zotero.org/oauth/request"  # noqa: S105 - URL, not a secret
+AUTHORIZE_URL = "https://www.zotero.org/oauth/authorize"
+ACCESS_TOKEN_URL = "https://www.zotero.org/oauth/access"  # noqa: S105 - URL, not a secret
+
+
+@dataclass(frozen=True)
+class ZoteroCredentials:
+    """Credentials produced by a completed OAuth handshake.
+
+    Attributes:
+        api_key: A Zotero API key usable for authenticated requests.
+        userid: The user's numeric Zotero ID, used as ``library_id``.
+        username: The user's Zotero username, if returned by the server.
+
+    """
+
+    api_key: str
+    userid: str
+    username: str | None = None
+
+    def client(self, **kwargs: Any) -> Zotero:
+        """Return a ``Zotero`` client configured with these credentials.
+
+        Any keyword arguments are forwarded to the ``Zotero`` constructor.
+        """
+        from ._client import Zotero  # noqa: PLC0415 - deferred to avoid import cost
+
+        return Zotero(
+            library_id=self.userid,
+            library_type="user",
+            api_key=self.api_key,
+            **kwargs,
+        )
+
+
+class ZoteroOAuth:
+    """Drive Zotero's OAuth 1.0a handshake to obtain an API key.
+
+    Args:
+        client_key: The application's OAuth client (consumer) key.
+        client_secret: The application's OAuth client (consumer) secret.
+        callback: The OAuth callback. Defaults to ``"oob"`` (out-of-band), in
+            which Zotero displays a verifier code for the user to copy. Web
+            applications should pass a registered redirect URL instead.
+        transport: An optional httpx transport, used to inject a mock transport
+            in tests. Mirrors the ``client`` injection seam on ``Zotero``.
+
+    """
+
+    def __init__(
+        self,
+        client_key: str,
+        client_secret: str,
+        callback: str = "oob",
+        *,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if OAuth1Client is None:
+            err = (
+                "OAuth support requires the 'oauth' extra. "
+                "Install it with: pip install pyzotero[oauth]"
+            )
+            raise OAuthError(err)
+        self.client_key = client_key
+        self.client_secret = client_secret
+        self.callback = callback
+        self._transport = transport
+        self._request_token: dict[str, str] | None = None
+
+    @property
+    def request_token(self) -> dict[str, str] | None:
+        """The temporary request token from the most recent ``authorize_url``.
+
+        Web applications can persist this between the request leg and the
+        access leg (which span separate HTTP requests) and supply it back via
+        the ``request_token`` argument to ``complete``/``complete_from_url``.
+        """
+        return self._request_token
+
+    def _make_client(self, **kwargs: Any) -> OAuth1Client:
+        """Build an OAuth1Client with the stored credentials and any transport."""
+        if self._transport is not None:
+            kwargs["transport"] = self._transport
+        return OAuth1Client(self.client_key, self.client_secret, **kwargs)
+
+    def authorize_url(
+        self,
+        *,
+        library_access: bool = True,
+        write_access: bool = False,
+        notes_access: bool = False,
+        all_groups: str = "read",
+        identity: bool = False,
+    ) -> str:
+        """Fetch a request token and return the URL to send the user to.
+
+        The boolean flags map to Zotero's permission parameters. ``all_groups``
+        sets the access level for current and future groups and must be one of
+        ``"none"``, ``"read"`` or ``"write"``. Setting ``identity`` requests the
+        user's identity only, without creating a key.
+
+        The request token is stored on the instance for a subsequent
+        ``complete`` call and is also available via ``request_token``.
+        """
+        params: dict[str, Any] = {}
+        if library_access:
+            params["library_access"] = 1
+        if write_access:
+            params["write_access"] = 1
+        if notes_access:
+            params["notes_access"] = 1
+        if all_groups:
+            params["all_groups"] = all_groups
+        if identity:
+            params["identity"] = 1
+        try:
+            with self._make_client(redirect_uri=self.callback) as client:
+                self._request_token = dict(
+                    client.fetch_request_token(REQUEST_TOKEN_URL)
+                )
+                return client.create_authorization_url(AUTHORIZE_URL, **params)
+        except _OAUTH_FAILURES as exc:
+            err = f"Failed to obtain an OAuth request token: {exc}"
+            raise OAuthError(err) from exc
+
+    def complete(
+        self,
+        verifier: str,
+        *,
+        request_token: dict[str, str] | None = None,
+    ) -> ZoteroCredentials:
+        """Exchange the approved request token for an API key.
+
+        Args:
+            verifier: The verifier code returned by Zotero after the user
+                approves the application.
+            request_token: The temporary request token. Optional when the same
+                instance performed ``authorize_url``; required when the access
+                leg runs in a separate process (e.g. a web request handler).
+
+        Returns:
+            A ``ZoteroCredentials`` carrying the API key and user ID.
+
+        """
+        token = request_token or self._request_token
+        if token is None:
+            err = (
+                "No request token available; call authorize_url() first "
+                "or pass request_token"
+            )
+            raise OAuthError(err)
+        try:
+            with self._make_client(
+                token=token["oauth_token"],
+                token_secret=token["oauth_token_secret"],
+            ) as client:
+                access = client.fetch_access_token(ACCESS_TOKEN_URL, verifier=verifier)
+        except _OAUTH_FAILURES as exc:
+            err = f"Failed to obtain an OAuth access token: {exc}"
+            raise OAuthError(err) from exc
+        try:
+            return ZoteroCredentials(
+                api_key=access["oauth_token"],
+                userid=str(access["userID"]),
+                username=access.get("username"),
+            )
+        except KeyError as exc:
+            err = f"OAuth access response was missing a required field: {exc}"
+            raise OAuthError(err) from exc
+
+    def complete_from_url(
+        self,
+        authorization_response: str,
+        *,
+        request_token: dict[str, str] | None = None,
+    ) -> ZoteroCredentials:
+        """Complete the handshake from a callback redirect URL.
+
+        Convenience for web applications: extracts the ``oauth_verifier`` query
+        parameter from the URL Zotero redirected the user to, then delegates to
+        ``complete``.
+        """
+        query = parse_qs(urlparse(authorization_response).query)
+        verifiers = query.get("oauth_verifier")
+        if not verifiers:
+            err = "No oauth_verifier found in the authorization response URL"
+            raise OAuthError(err)
+        return self.complete(verifiers[0], request_token=request_token)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,155 @@
+"""Tests for the OAuth 1.0a key-acquisition helper.
+
+The three Zotero OAuth endpoints are stubbed with an httpx MockTransport
+injected via the ``transport`` seam, so no network access is required.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from pyzotero.cli import main
+from pyzotero.errors import OAuthError
+from pyzotero.oauth import ZoteroCredentials, ZoteroOAuth
+
+
+REQUEST_BODY = (
+    "oauth_token=tmpTOKEN&oauth_token_secret=tmpSECRET&oauth_callback_confirmed=true"
+)
+ACCESS_BODY = "oauth_token=REALKEY&oauth_token_secret=REALKEY&userID=12345&username=foo"
+
+
+def _transport(*, request_status: int = 200, access_status: int = 200):
+    """Return a MockTransport stubbing the three OAuth endpoints."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "oauth/request" in url:
+            return httpx.Response(request_status, text=REQUEST_BODY)
+        if "oauth/access" in url:
+            return httpx.Response(access_status, text=ACCESS_BODY)
+        return httpx.Response(404, text="not found")
+
+    return httpx.MockTransport(handler)
+
+
+def test_authorize_url_contains_token_and_params():
+    oauth = ZoteroOAuth("ck", "cs", transport=_transport())
+    url = oauth.authorize_url(write_access=True)
+    assert "oauth_token=tmpTOKEN" in url
+    assert "write_access=1" in url
+    assert "library_access=1" in url
+    assert "all_groups=read" in url
+    # the request token is stashed for the subsequent complete() call
+    assert oauth.request_token == {
+        "oauth_token": "tmpTOKEN",
+        "oauth_token_secret": "tmpSECRET",
+        "oauth_callback_confirmed": "true",
+    }
+
+
+def test_authorize_url_omits_unrequested_permissions():
+    oauth = ZoteroOAuth("ck", "cs", transport=_transport())
+    url = oauth.authorize_url(library_access=False, all_groups="none")
+    assert "library_access" not in url
+    assert "write_access" not in url
+    assert "all_groups=none" in url
+
+
+def test_complete_returns_credentials():
+    oauth = ZoteroOAuth("ck", "cs", transport=_transport())
+    oauth.authorize_url()
+    creds = oauth.complete("verifier123")
+    assert creds == ZoteroCredentials(api_key="REALKEY", userid="12345", username="foo")
+
+
+def test_credentials_client_builds_zotero():
+    creds = ZoteroCredentials(api_key="REALKEY", userid="12345", username="foo")
+    zot = creds.client()
+    assert zot.library_id == "12345"
+    assert zot.library_type == "users"
+    assert zot.api_key == "REALKEY"
+
+
+def test_complete_from_url_extracts_verifier():
+    oauth = ZoteroOAuth("ck", "cs", transport=_transport())
+    oauth.authorize_url()
+    callback = "https://app.example/callback?oauth_token=tmpTOKEN&oauth_verifier=abc"
+    creds = oauth.complete_from_url(callback)
+    assert creds.api_key == "REALKEY"
+
+
+def test_complete_with_supplied_request_token():
+    # Simulates a web app where the access leg runs in a separate instance.
+    oauth = ZoteroOAuth("ck", "cs", transport=_transport())
+    token = {"oauth_token": "tmpTOKEN", "oauth_token_secret": "tmpSECRET"}
+    creds = oauth.complete("verifier123", request_token=token)
+    assert creds.userid == "12345"
+
+
+def test_request_token_failure_raises_oautherror():
+    oauth = ZoteroOAuth("ck", "cs", transport=_transport(request_status=401))
+    with pytest.raises(OAuthError, match="request token"):
+        oauth.authorize_url()
+
+
+def test_access_token_failure_raises_oautherror():
+    oauth = ZoteroOAuth("ck", "cs", transport=_transport(access_status=401))
+    oauth.authorize_url()
+    with pytest.raises(OAuthError, match="access token"):
+        oauth.complete("verifier123")
+
+
+def test_complete_without_request_token_raises():
+    oauth = ZoteroOAuth("ck", "cs", transport=_transport())
+    with pytest.raises(OAuthError, match="No request token"):
+        oauth.complete("verifier123")
+
+
+def test_complete_from_url_without_verifier_raises():
+    oauth = ZoteroOAuth("ck", "cs", transport=_transport())
+    oauth.authorize_url()
+    with pytest.raises(OAuthError, match="oauth_verifier"):
+        oauth.complete_from_url("https://app.example/callback?oauth_token=tmpTOKEN")
+
+
+def test_missing_extra_raises(monkeypatch):
+    monkeypatch.setattr("pyzotero.oauth.OAuth1Client", None)
+    with pytest.raises(OAuthError, match="oauth"):
+        ZoteroOAuth("ck", "cs")
+
+
+def test_cli_auth_command(monkeypatch):
+    transport = _transport()
+    # Inject the mock transport into the class the CLI constructs.
+    monkeypatch.setattr(
+        "pyzotero.oauth.ZoteroOAuth",
+        functools.partial(ZoteroOAuth, transport=transport),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["auth", "--client-key", "ck", "--client-secret", "cs", "--write"],
+        input="verifier123\n",
+    )
+    assert result.exit_code == 0
+    assert "library_id: 12345" in result.output
+    assert "api_key:    REALKEY" in result.output
+
+
+def test_cli_auth_reads_env_credentials(monkeypatch):
+    transport = _transport()
+    monkeypatch.setattr(
+        "pyzotero.oauth.ZoteroOAuth",
+        functools.partial(ZoteroOAuth, transport=transport),
+    )
+    monkeypatch.setenv("ZOTERO_CLIENT_KEY", "ck")
+    monkeypatch.setenv("ZOTERO_CLIENT_SECRET", "cs")
+    runner = CliRunner()
+    result = runner.invoke(main, ["auth"], input="verifier123\n")
+    assert result.exit_code == 0
+    assert "api_key:    REALKEY" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -67,6 +67,19 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -527,7 +540,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -636,17 +649,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -662,18 +675,18 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
@@ -685,7 +698,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -714,6 +727,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
 ]
 
 [[package]]
@@ -1307,6 +1332,9 @@ cli = [
 mcp = [
     { name = "mcp", extra = ["cli"] },
 ]
+oauth = [
+    { name = "authlib" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1328,6 +1356,7 @@ doc = [
 
 [package.metadata]
 requires-dist = [
+    { name = "authlib", marker = "extra == 'oauth'", specifier = ">=1.7.2" },
     { name = "bibtexparser", specifier = ">=1.4.3,<2.0.0" },
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.0.0" },
     { name = "feedparser", specifier = ">=6.0.12" },
@@ -1335,7 +1364,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "whenever", specifier = ">=0.8.8" },
 ]
-provides-extras = ["cli", "mcp"]
+provides-extras = ["cli", "mcp", "oauth"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1711,23 +1740,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -1742,23 +1771,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -1773,23 +1802,23 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -70,6 +70,19 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -533,7 +546,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -642,17 +655,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -671,18 +684,18 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
@@ -694,7 +707,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -723,6 +736,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
 ]
 
 [[package]]
@@ -1316,6 +1341,9 @@ cli = [
 mcp = [
     { name = "mcp", extra = ["cli"] },
 ]
+oauth = [
+    { name = "authlib" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1337,6 +1365,7 @@ doc = [
 
 [package.metadata]
 requires-dist = [
+    { name = "authlib", marker = "extra == 'oauth'", specifier = ">=1.7.2" },
     { name = "bibtexparser", specifier = ">=1.4.3,<2.0.0" },
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.0.0" },
     { name = "feedparser", specifier = ">=6.0.12" },
@@ -1344,7 +1373,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "whenever", specifier = ">=0.8.8" },
 ]
-provides-extras = ["cli", "mcp"]
+provides-extras = ["cli", "mcp", "oauth"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1723,23 +1752,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -1754,23 +1783,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -1788,23 +1817,23 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [


### PR DESCRIPTION
Add a self-contained ZoteroOAuth helper plus ZoteroCredentials dataclass that drive Zotero's OAuth 1.0a handshake to obtain an API key + user ID. Authlib provides the OAuth 1.0a signing via a new optional [oauth] extra. Adds OAuthError and exports the new public symbols from the package root.

<!-- Thanks for opening a PR. Please read the following:

- **Base your changes on the `main` branch**
    - If necessary, rebase against `main` before opening a pull request
- This codebase uses Ruff. PRs that reformat code will not be accepted.
- Ensure that all methods added have a proper docstring. **Please do not use Doctest**
- If at all possible, don't add dependencies
    - If it is unavoidable, you must ensure that the dependency is maintained, and supported
    - Ensure that you add your dependency to [pyproject.toml](pyproject.toml)
- Run the tests and ensure that they pass. If you are adding a feature **you must add tests that exercise it**
- If your pull request is a feature **document the feature**
- One feature per pull request
- [squash](http://git-scm.com/book/en/Git-Tools-Rewriting-History#Squashing-Commits) your commits before opening a pull request unless it makes no sense to do so
- If in doubt, comment your code.

## License of Contributed Code
Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be licensed under the Blue Oak Model License 1.0, without any additional terms or conditions.  
Please note that pull requests with licenses that are more restrictive than or otherwise incompatible with the license will not be accepted. -->

Description of changes:
Issue reference (if applicable):

- [ ] I have read [the CONTRIBUTING doc](CONTRIBUTING.md)
