### PR TITLE
Return None from follow() when pagination is exhausted

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -793,6 +793,8 @@ These methods (currently experimental) aim to make Pyzotero a little more RESTfu
 
 .. py:method:: Zotero.follow()
 
+    Returns ``None`` once all available items have been retrieved.
+
 Example:
 
     .. code-block:: python
@@ -805,6 +807,17 @@ Example:
         # now we can start retrieving subsequent items
         next_item = zot.follow()
         third_item = zot.follow()
+
+    ``follow()`` can thus be used to page through an entire library:
+
+    .. code-block:: python
+
+        items = zot.items()
+        while items:
+            for item in items:
+                # do stuff with the item
+                ...
+            items = zot.follow()
 
 
 .. py:method:: Zotero.everything()

--- a/src/pyzotero/_client.py
+++ b/src/pyzotero/_client.py
@@ -722,12 +722,21 @@ class Zotero:
         """Retrieve all top-level items."""
         return self.everything(self.top(**kwargs))
 
-    @retrieve  # ty: ignore[invalid-argument-type]
-    def follow(self) -> str | None:
-        """Return the result of the call to the URL in the 'Next' link."""
-        if n := self.links.get("next"):
-            return self._striplocal(n)
-        return None
+    def follow(self) -> Any:
+        """Return the result of the call to the URL in the 'Next' link.
+
+        Returns None when there are no more pages to retrieve.
+        """
+        # Bail out before making a request: without a 'next' link, the
+        # decorated helper would end up querying the bare API root
+        if not self.links or not self.links.get("next"):
+            return None
+        return self._follow_next()
+
+    @retrieve
+    def _follow_next(self) -> str:
+        """Retrieve the URL in the 'next' link. Only called by follow()."""
+        return self._striplocal(self.links["next"])
 
     def iterfollow(self) -> Generator[Any, None, None]:
         """Return generator for self.follow()."""

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -1986,6 +1986,34 @@ class ZoteroTests(unittest.TestCase):
         # The 'next' link used by follow() must be unchanged
         self.assertEqual(zot.links["next"], next_link)
 
+    def test_follow_exhausted_returns_none(self):
+        """follow() must return None once pagination is exhausted (#350)"""
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+
+        # Final page of results: no 'next' relation in the Link header
+        mock.register(
+            "GET",
+            "https://api.zotero.org/users/myuserID/items",
+            body=self.items_doc,
+            content_type="application/json",
+        )
+
+        items = zot.items()
+        self.assertTrue(items)
+        request_count = len(mock.latest_requests())
+
+        # No 'next' link, so follow() must return None without
+        # making a request (previously it hit the bare API root,
+        # returning b'Nothing to see here.')
+        self.assertIsNone(zot.follow())
+        self.assertEqual(len(mock.latest_requests()), request_count)
+
+    def test_follow_without_previous_call_returns_none(self):
+        """follow() before any API call must return None, not raise"""
+        zot = z.Zotero("myuserID", "user", "myuserkey")
+        self.assertIsNone(zot.follow())
+
     def test_makeiter(self):
         """Test the makeiter method that wraps iterfollow"""
         zot = z.Zotero("myuserID", "user", "myuserkey")


### PR DESCRIPTION
Description of changes:
`follow()` was decorated with `@retrieve`, so when there was no `next` link it returned `None` as the query string, and `_retrieve_data()` then requested the bare API root — which responds with the literal `text/plain` body `b'Nothing to see here.'`. Callers looping with `while items:` would then iterate over the bytes of that string.

The retrieval is now split into a private `@retrieve`-decorated `_follow_next()` helper, so `follow()` can short-circuit to `None` — without making any HTTP request — when there is no `next` link, including when no paginated call has been made yet (previously an `AttributeError`). `everything()` and `iterfollow()` already guard on the `next` link themselves and are unchanged.

Includes two regression tests (exhausted pagination returns `None` with no extra request; `follow()` before any call returns `None`) and documents the `None` return plus a `while items:` paging-loop example in `doc/index.rst`.

Issue reference (if applicable): Closes #350

- [x] I have read [the CONTRIBUTING doc](CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fD6npE2uyi9e33JQf5LBM

---
_Generated by [Claude Code](https://claude.ai/code/session_016fD6npE2uyi9e33JQf5LBM)_