### PR TITLE
Retry rate-limited requests instead of returning the 429 error body

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyzotero"
-version = "1.13.4"
+version = "1.13.5"
 description = "Python wrapper for the Zotero API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pyzotero/_client.py
+++ b/src/pyzotero/_client.py
@@ -39,6 +39,7 @@ from ._utils import (
     DEFAULT_ITEM_LIMIT,
     DEFAULT_NUM_ITEMS,
     DEFAULT_TIMEOUT,
+    MAX_RETRY_ATTEMPTS,
     ONE_HOUR,
     build_url,
     chunks,
@@ -274,8 +275,6 @@ class Zotero:
         if request is None:
             request = ""
         full_url = build_url(self.endpoint, request)
-        # ensure that we wait if there's an active backoff
-        self._check_backoff()
         # don't set locale if the url already contains it
         # we always add a locale if it's a "standalone" or first call
         needs_locale = not self.links or not self._check_for_component(
@@ -297,31 +296,40 @@ class Zotero:
         # Unfortunately, httpx doesn't like to merge query parameters in the url string and passed params
         # so we strip the url params, combining them with our existing url_params
         final_url, final_params = merge_params(full_url, merged_params)
-        # file URI errors are raised immediately so we have to try here
-        try:
-            self.request = self.client.get(
-                url=final_url,
-                params=final_params,
-                timeout=DEFAULT_TIMEOUT,
-            )
-            self.request.encoding = "utf-8"
-            # The API doesn't return this any more, so we have to cheat
-            self.self_link = self.request.url
-        except httpx.UnsupportedProtocol:
-            # File URI handler logic
-            fc = File_Client()
-            response = fc.get(
-                url=final_url,
-                params=final_params,
-                headers=self.default_headers(),
-                timeout=DEFAULT_TIMEOUT,
-                follow_redirects=True,
-            )
-            self.request = response
-            # since we'll be writing bytes, we need to set this to a type that will trigger the bytes processor
-            self.request.headers["Content-Type"] = "text/plain"
-        self._post_check(self.request)
-        return self.request
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            # ensure that we wait if there's an active backoff
+            self._check_backoff()
+            # file URI errors are raised immediately so we have to try here
+            try:
+                self.request = self.client.get(
+                    url=final_url,
+                    params=final_params,
+                    timeout=DEFAULT_TIMEOUT,
+                )
+                self.request.encoding = "utf-8"
+                # The API doesn't return this any more, so we have to cheat
+                self.self_link = self.request.url
+            except httpx.UnsupportedProtocol:
+                # File URI handler logic
+                fc = File_Client()
+                response = fc.get(
+                    url=final_url,
+                    params=final_params,
+                    headers=self.default_headers(),
+                    timeout=DEFAULT_TIMEOUT,
+                    follow_redirects=True,
+                )
+                self.request = response
+                # since we'll be writing bytes, we need to set this to a type that will trigger the bytes processor
+                self.request.headers["Content-Type"] = "text/plain"
+            self._post_check(self.request)
+            # On 429, error_handler records the server's backoff instead of
+            # raising; _check_backoff waits it out, so retry rather than
+            # handing the error body back as though it were a payload
+            if self.request.status_code != httpx.codes.TOO_MANY_REQUESTS:
+                return self.request
+        msg = f"Still rate-limited after {MAX_RETRY_ATTEMPTS} attempts. Try again later"
+        raise ze.TooManyRetriesError(msg)
 
     def _extract_links(self) -> dict[str, str] | None:
         """Extract self, first, next, last links from a request response."""

--- a/src/pyzotero/_decorators.py
+++ b/src/pyzotero/_decorators.py
@@ -18,8 +18,8 @@ import bibtexparser
 import feedparser
 import httpx
 
-from ._utils import DEFAULT_TIMEOUT, get_backoff_duration
-from .errors import error_handler
+from ._utils import DEFAULT_TIMEOUT, MAX_RETRY_ATTEMPTS, get_backoff_duration
+from .errors import TooManyRetriesError, error_handler
 
 if TYPE_CHECKING:
     from ._client import Zotero
@@ -82,19 +82,27 @@ def backoff_check(
 
     @wraps(func)
     def wrapped_f(self: Zotero, *args: Any, **kwargs: Any) -> bool:
-        self._check_backoff()
-        # resp is a Requests response object
-        resp = func(self, *args, **kwargs)
-        try:
-            resp.raise_for_status()
-        except httpx.HTTPError as exc:
-            error_handler(self, resp, exc)
-        self.request = resp
-        backoff = get_backoff_duration(resp.headers)
-        if backoff:
-            self._set_backoff(backoff)
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            self._check_backoff()
+            # resp is a Requests response object
+            resp = func(self, *args, **kwargs)
+            try:
+                resp.raise_for_status()
+            except httpx.HTTPError as exc:
+                error_handler(self, resp, exc)
+            self.request = resp
+            # On 429 the write was refused and error_handler recorded the
+            # server's backoff; _check_backoff waits it out, so retry
+            # rather than reporting success
+            if resp.status_code == httpx.codes.TOO_MANY_REQUESTS:
+                continue
+            backoff = get_backoff_duration(resp.headers)
+            if backoff:
+                self._set_backoff(backoff)
 
-        return True
+            return True
+        msg = f"Still rate-limited after {MAX_RETRY_ATTEMPTS} attempts. Try again later"
+        raise TooManyRetriesError(msg)
 
     return wrapped_f
 

--- a/src/pyzotero/_upload.py
+++ b/src/pyzotero/_upload.py
@@ -17,10 +17,12 @@ import httpx
 import pyzotero as pz
 
 from . import errors as ze
-from ._utils import build_url, get_backoff_duration, token
+from ._utils import MAX_RETRY_ATTEMPTS, build_url, get_backoff_duration, token
 from .errors import error_handler
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ._client import Zotero
     from ._types import JsonDict
 
@@ -53,6 +55,22 @@ class Zupload:
         backoff = get_backoff_duration(req.headers)
         if backoff:
             self.zinstance._set_backoff(backoff)
+
+    def _post_with_retry(self, send: Callable[[], httpx.Response]) -> httpx.Response:
+        """Issue a request via ``send``, retrying while the server rate-limits us.
+
+        On 429, error_handler records the server's backoff instead of raising;
+        _check_backoff waits it out before the next attempt. This stops a
+        rate-limited step from being mistaken for a successful one (#352).
+        """
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            self.zinstance._check_backoff()
+            req = send()
+            self._check_response(req)
+            if req.status_code != httpx.codes.TOO_MANY_REQUESTS:
+                return req
+        msg = f"Still rate-limited after {MAX_RETRY_ATTEMPTS} attempts. Try again later"
+        raise ze.TooManyRetriesError(msg)
 
     def _verify(self, payload: list[dict]) -> None:
         """Ensure that all files to be attached exist.
@@ -107,19 +125,19 @@ class Zupload:
             for child in self.payload:
                 child["parentItem"] = self.parentid
         to_send = json.dumps([self._outgoing(item) for item in self.payload])
-        self.zinstance._check_backoff()
-        req = self.zinstance.client.post(
-            url=build_url(
-                self.zinstance.endpoint,
-                liblevel.format(
-                    t=self.zinstance.library_type,
-                    u=self.zinstance.library_id,
+        req = self._post_with_retry(
+            lambda: self.zinstance.client.post(
+                url=build_url(
+                    self.zinstance.endpoint,
+                    liblevel.format(
+                        t=self.zinstance.library_type,
+                        u=self.zinstance.library_id,
+                    ),
                 ),
-            ),
-            content=to_send,
-            headers=headers,
+                content=to_send,
+                headers=headers,
+            )
         )
-        self._check_response(req)
         data = req.json()
         for k in data["success"]:
             self.payload[int(k)]["key"] = data["success"][k]
@@ -151,16 +169,16 @@ class Zupload:
             "charset": mtypes[1],
             "params": 1,
         }
-        self.zinstance._check_backoff()
-        auth_req = self.zinstance.client.post(
-            url=build_url(
-                self.zinstance.endpoint,
-                f"/{self.zinstance.library_type}/{self.zinstance.library_id}/items/{reg_key}/file",
-            ),
-            data=data,
-            headers=auth_headers,
+        auth_req = self._post_with_retry(
+            lambda: self.zinstance.client.post(
+                url=build_url(
+                    self.zinstance.endpoint,
+                    f"/{self.zinstance.library_type}/{self.zinstance.library_id}/items/{reg_key}/file",
+                ),
+                data=data,
+                headers=auth_headers,
+            )
         )
-        self._check_response(auth_req)
         return auth_req.json()
 
     def _upload_file(
@@ -183,23 +201,25 @@ class Zupload:
             upload_list.append((key, value))
         upload_list.append(("file", Path(attachment).read_bytes()))
         upload_pairs = tuple(upload_list)
-        try:
-            self.zinstance._check_backoff()
+
+        def send() -> httpx.Response:
             # We use a fresh httpx POST because we don't want our existing Pyzotero headers
             # for a call to the storage upload URL (currently S3)
-            upload = httpx.post(
-                url=authdata["url"],
-                files=upload_pairs,
-                headers={"User-Agent": f"Pyzotero/{pz.__version__}"},
-                timeout=self.zinstance.upload_timeout,
-            )
-        except httpx.ConnectError:
-            msg = "ConnectionError"
-            raise ze.UploadError(msg) from None
-        except httpx.TimeoutException:
-            msg = "Upload timed out. Try increasing upload_timeout when creating the Zotero instance."
-            raise ze.UploadError(msg) from None
-        self._check_response(upload)
+            try:
+                return httpx.post(
+                    url=authdata["url"],
+                    files=upload_pairs,
+                    headers={"User-Agent": f"Pyzotero/{pz.__version__}"},
+                    timeout=self.zinstance.upload_timeout,
+                )
+            except httpx.ConnectError:
+                msg = "ConnectionError"
+                raise ze.UploadError(msg) from None
+            except httpx.TimeoutException:
+                msg = "Upload timed out. Try increasing upload_timeout when creating the Zotero instance."
+                raise ze.UploadError(msg) from None
+
+        self._post_with_retry(send)
         # now check the responses
         return self._register_upload(authdata, reg_key, md5=md5)
 
@@ -218,16 +238,16 @@ class Zupload:
         else:
             reg_headers["If-None-Match"] = "*"
         reg_data = {"upload": authdata.get("uploadKey")}
-        self.zinstance._check_backoff()
-        upload_reg = self.zinstance.client.post(
-            url=build_url(
-                self.zinstance.endpoint,
-                f"/{self.zinstance.library_type}/{self.zinstance.library_id}/items/{reg_key}/file",
-            ),
-            data=reg_data,
-            headers=reg_headers,
+        self._post_with_retry(
+            lambda: self.zinstance.client.post(
+                url=build_url(
+                    self.zinstance.endpoint,
+                    f"/{self.zinstance.library_type}/{self.zinstance.library_id}/items/{reg_key}/file",
+                ),
+                data=reg_data,
+                headers=reg_headers,
+            )
         )
-        self._check_response(upload_reg)
 
     def upload(self) -> dict[str, list]:
         """File upload functionality.

--- a/src/pyzotero/_utils.py
+++ b/src/pyzotero/_utils.py
@@ -21,6 +21,10 @@ ONE_HOUR = 3600
 DEFAULT_NUM_ITEMS = 50
 DEFAULT_ITEM_LIMIT = 100
 
+# How many times a request is attempted when the server rate-limits us (429)
+# before TooManyRetriesError is raised
+MAX_RETRY_ATTEMPTS = 3
+
 T = TypeVar("T")
 
 
@@ -80,6 +84,7 @@ __all__ = [
     "DEFAULT_ITEM_LIMIT",
     "DEFAULT_NUM_ITEMS",
     "DEFAULT_TIMEOUT",
+    "MAX_RETRY_ATTEMPTS",
     "ONE_HOUR",
     "build_url",
     "chunks",

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -1145,6 +1145,63 @@ class ZoteroTests(unittest.TestCase):
         # Clean up
         os.remove(temp_file_path)
 
+    def testFileUploadPrelimRateLimitRetried(self):
+        """A 429 during upload step 0 is retried, not JSON-decoded (#352)"""
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+        attempts = []
+
+        def rate_limited_once(request, uri, headers):
+            attempts.append(uri)
+            if len(attempts) == 1:
+                headers["content-type"] = "text/plain"
+                headers["backoff"] = "0.1"
+                return [429, headers, "Too many requests. Slow down"]
+            return [200, headers, json.dumps({"success": {"0": "ITEMKEY123"}})]
+
+        mock.register(
+            "POST",
+            "https://api.zotero.org/users/myuserID/items",
+            body=rate_limited_once,
+        )
+
+        payload = [
+            {
+                "filename": "test_upload_file.txt",
+                "title": "Test File",
+                "linkMode": "imported_file",
+            }
+        ]
+        mock_auth_data = {"exists": True}
+        with (
+            patch.object(z.Zupload, "_verify", return_value=None),
+            patch.object(z.Zupload, "_get_auth", return_value=mock_auth_data),
+        ):
+            upload = z.Zupload(zot, payload)
+            result = upload.upload()
+
+        self.assertEqual(len(attempts), 2)
+        self.assertEqual(result["unchanged"][0]["key"], "ITEMKEY123")
+
+    def testFileUploadRegisterRateLimitRaises(self):
+        """A persistent 429 registering an upload raises instead of silently
+        reporting success (#352)
+        """
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+        mock.register(
+            "POST",
+            "https://api.zotero.org/users/myuserID/items/ITEMKEY123/file",
+            status=429,
+            body="Too many requests. Slow down",
+            content_type="text/plain",
+            headers={"backoff": 0.1},
+        )
+        upload = z.Zupload(zot, [{"filename": "nonexistent.txt"}])
+        with self.assertRaises(z.ze.TooManyRetriesError):
+            upload._register_upload({"uploadKey": "upload_key_123"}, "ITEMKEY123")
+        self.assertEqual(len(mock.latest_requests()), MAX_RETRY_ATTEMPTS)
+
     def testFileUploadWithParentItem(self):
         """Tests file upload process with a parent item ID"""
         mock = MockClient()

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -18,6 +18,8 @@ import pytz
 import whenever
 from dateutil import parser
 
+from pyzotero._utils import MAX_RETRY_ATTEMPTS
+
 from .mock_client import MockClient
 
 try:
@@ -848,19 +850,72 @@ class ZoteroTests(unittest.TestCase):
             zot.create_items(itms)
 
     def testRateLimitWithBackoff(self):
-        """Test 429 response handling when a backoff header is received"""
+        """A persistent 429 is retried, then raises instead of returning the
+        error body as bytes (#352)
+        """
         mock = MockClient()
         zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
         mock.register(
             "GET",
             "https://api.zotero.org/users/myuserID/items",
             status=429,
-            body="[]",
+            body="Too many requests. Slow down",
+            content_type="text/plain",
             headers={"backoff": 0.1},
         )
-        zot.items()
+        with self.assertRaises(z.ze.TooManyRetriesError):
+            zot.items()
+        # every allowed attempt was made before giving up
+        self.assertEqual(len(mock.latest_requests()), MAX_RETRY_ATTEMPTS)
         # backoff_until should be in the future
         self.assertGreater(zot.backoff_until, time.time())
+
+    def testRateLimitRetryReturnsPayload(self):
+        """A 429 followed by a success returns the real payload (#352)"""
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+        attempts = []
+
+        def rate_limited_once(request, uri, headers):
+            attempts.append(uri)
+            if len(attempts) == 1:
+                headers["content-type"] = "text/plain"
+                headers["backoff"] = "0.1"
+                return [429, headers, "Too many requests. Slow down"]
+            return [200, headers, self.items_doc]
+
+        mock.register(
+            "GET",
+            "https://api.zotero.org/users/myuserID/items",
+            body=rate_limited_once,
+        )
+        items = zot.items()
+        self.assertEqual(len(attempts), 2)
+        self.assertIsInstance(items, list)
+        self.assertEqual(items[0]["key"], "NM66T6EF")
+
+    def testRateLimitWriteRetried(self):
+        """A 429 on a write is retried instead of reporting success (#352)"""
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+        attempts = []
+
+        def rate_limited_once(request, uri, headers):
+            attempts.append(uri)
+            if len(attempts) == 1:
+                headers["content-type"] = "text/plain"
+                headers["backoff"] = "0.1"
+                return [429, headers, "Too many requests. Slow down"]
+            return [204, headers, ""]
+
+        mock.register(
+            "PUT",
+            "https://api.zotero.org/users/myuserID/items/ABCD2345/fulltext",
+            body=rate_limited_once,
+        )
+        result = zot.set_fulltext("ABCD2345", {"content": "hi", "indexedChars": 2})
+        self.assertTrue(result)
+        self.assertEqual(len(attempts), 2)
 
     def testDeleteTags(self):
         """Tests deleting tags"""

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ wheels = [
 
 [[package]]
 name = "pyzotero"
-version = "1.13.4"
+version = "1.13.5"
 source = { editable = "." }
 dependencies = [
     { name = "bibtexparser" },


### PR DESCRIPTION
Description of changes:
Since `8840e3d` (v1.4.3, 2019), `error_handler` has recorded the server-supplied backoff on HTTP 429 and returned without raising, on the premise that the caller would retry — but no caller did. Read methods handed the 429 response to the `@retrieve` format dispatcher, whose `text/plain` fallback returned the error body as `bytes` (iterating as `int`s, with a plausible-looking `len()`). Write methods decorated with `@backoff_check` returned `True` even though the write had been refused. The four-step attachment upload flow shared the same flaw: steps 0–1 crashed with a `JSONDecodeError` on the error body, and steps 2–3 continued silently, so `upload()` could report success for an attachment that was never uploaded or registered.

This honours the original contract everywhere: `_retrieve_data` (all reads), `backoff_check` (all writes), and a new `Zupload._post_with_retry` (all four upload steps) now wait out the recorded backoff via `_check_backoff()` and retry, raising `TooManyRetriesError` after `MAX_RETRY_ATTEMPTS` (3) attempts. A 429 can therefore never reach format dispatch, masquerade as a successful write, or corrupt an upload. The issue's reproduction script now raises `TooManyRetriesError` instead of returning the error body.

Tests: `testRateLimitWithBackoff` previously asserted the silent-return behaviour and has been rewritten (persistent 429 → 3 attempts → raise); new tests cover a 429-then-200 read returning the real payload, a 429-then-204 write retrying before returning `True`, a retried 429 during upload step 0, and a persistent 429 during upload registration raising instead of reporting success. Also bumps the version to 1.13.5, since v1.13.4 is already tagged.

Issue reference (if applicable): Closes #352

- [x] I have read [the CONTRIBUTING doc](CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fD6npE2uyi9e33JQf5LBM