### PR TITLE
Return the item version on upload-created attachments

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1108,7 +1108,7 @@ Uploading files
             }
 
     .. note::
-        unlike the space-saving responses from the server, the return value here eschews the complex index / key lookup and simply passes back the ``imported_file`` item template populated with keys (if created successfully or passed in) corresponding to each result. This is the return type for all of these methods.
+        unlike the space-saving responses from the server, the return value here eschews the complex index / key lookup and simply passes back the ``imported_file`` item template populated with keys (if created successfully or passed in) corresponding to each result. This is the return type for all of these methods. Entries additionally carry the item's current ``version`` (as reported by the server after the item's final write step), so a follow-up :py:meth:`Zotero.update_item()` call can be made without refetching the item first.
 
     .. note::
         the ``filename`` you pass is used to locate the file on disk (relative to ``basedir``, if given), so it may be a path. The API doesn't accept a directory path in a stored-file item's ``filename`` field, so only the basename is sent when the attachment item is created. Entries returned under ``failure`` because the server rejected the item at creation time contain the server's reason under an ``error`` key, e.g. ``{'code': 400, 'message': '…'}``.

--- a/src/pyzotero/_upload.py
+++ b/src/pyzotero/_upload.py
@@ -45,6 +45,11 @@ class Zupload:
         self.payload = payload
         self.parentid = parentid
         self.basedir = Path() if basedir is None else Path(basedir)
+        # Tracks the Last-Modified-Version header across upload steps: every
+        # write in this flow sets the objects it modifies to that version,
+        # so the value after an item's final write step is that item's
+        # current version (see #354)
+        self.last_modified_version: int | None = None
 
     def _check_response(self, req: httpx.Response) -> None:
         """Raise on HTTP error and record any server-supplied backoff."""
@@ -68,6 +73,8 @@ class Zupload:
             req = send()
             self._check_response(req)
             if req.status_code != httpx.codes.TOO_MANY_REQUESTS:
+                if lmv := req.headers.get("last-modified-version"):
+                    self.last_modified_version = int(lmv)
                 return req
         msg = f"Still rate-limited after {MAX_RETRY_ATTEMPTS} attempts. Try again later"
         raise ze.TooManyRetriesError(msg)
@@ -139,8 +146,16 @@ class Zupload:
             )
         )
         data = req.json()
+        # 'successful' holds the full saved objects, including their versions;
+        # fall back to the response's Last-Modified-Version, which every
+        # object written by this request was set to
+        successful = data.get("successful") or {}
         for k in data["success"]:
-            self.payload[int(k)]["key"] = data["success"][k]
+            entry = self.payload[int(k)]
+            entry["key"] = data["success"][k]
+            version = successful.get(k, {}).get("version") or self.last_modified_version
+            if version:
+                entry["version"] = version
         return data
 
     def _get_auth(
@@ -271,11 +286,24 @@ class Zupload:
             authdata = self._get_auth(attach, item["key"], md5=item.get("md5", None))
             # no need to keep going if the file exists
             if authdata.get("exists"):
+                self._set_version(item)
                 result["unchanged"].append(item)
                 continue
             self._upload_file(authdata, attach, item["key"], md5=item.get("md5", None))
+            self._set_version(item)
             result["success"].append(item)
         return result
+
+    def _set_version(self, item: JsonDict) -> None:
+        """Stamp an item with the version its last write step set it to.
+
+        Registering an upload (and, for existing files, authorisation)
+        modifies the attachment item again after creation, so the version
+        captured at creation time would be stale by the time upload()
+        returns (#354).
+        """
+        if self.last_modified_version:
+            item["version"] = self.last_modified_version
 
 
 __all__ = ["Zupload"]

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -1202,6 +1202,102 @@ class ZoteroTests(unittest.TestCase):
             upload._register_upload({"uploadKey": "upload_key_123"}, "ITEMKEY123")
         self.assertEqual(len(mock.latest_requests()), MAX_RETRY_ATTEMPTS)
 
+    def testFileUploadCapturesVersion(self):
+        """Uploaded entries carry the version set by upload registration (#354)"""
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+
+        temp_file_path = os.path.join(self.cwd, "api_responses", "test_upload_file.txt")
+        with open(temp_file_path, "w") as f:
+            f.write("Test file content for upload")
+
+        # Step 0: creation response carries versions in 'successful'
+        prelim_response = {
+            "success": {"0": "ITEMKEY123"},
+            "successful": {"0": {"key": "ITEMKEY123", "version": 100}},
+            "unchanged": {},
+            "failed": {},
+        }
+        mock.register(
+            "POST",
+            "https://api.zotero.org/users/myuserID/items",
+            body=json.dumps(prelim_response),
+            headers={"last-modified-version": "100"},
+        )
+        # Step 3: registration bumps the item's version again
+        mock.register(
+            "POST",
+            "https://api.zotero.org/users/myuserID/items/ITEMKEY123/file",
+            status=204,
+            body="",
+            headers={"last-modified-version": "101"},
+        )
+
+        payload = [
+            {
+                "filename": "test_upload_file.txt",
+                "title": "Test File",
+                "linkMode": "imported_file",
+            }
+        ]
+        mock_auth_data = {
+            "url": "https://uploads.zotero.org/",
+            "params": {"key": "abcdef1234567890"},
+            "uploadKey": "upload_key_123",
+        }
+        s3_response = httpx.Response(
+            201, request=httpx.Request("POST", "https://uploads.zotero.org/")
+        )
+        with (
+            patch.object(z.Zupload, "_verify", return_value=None),
+            patch.object(z.Zupload, "_get_auth", return_value=mock_auth_data),
+            patch("pyzotero._upload.httpx.post", return_value=s3_response),
+        ):
+            upload = z.Zupload(
+                zot, payload, basedir=os.path.join(self.cwd, "api_responses")
+            )
+            result = upload.upload()
+
+        # the registration step's version, not the creation step's
+        self.assertEqual(result["success"][0]["key"], "ITEMKEY123")
+        self.assertEqual(result["success"][0]["version"], 101)
+
+        os.remove(temp_file_path)
+
+    def testFileUploadExistsCapturesVersion(self):
+        """Entries for already-existing files carry the creation version (#354)"""
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+
+        prelim_response = {
+            "success": {"0": "ITEMKEY123"},
+            "successful": {"0": {"key": "ITEMKEY123", "version": 100}},
+            "unchanged": {},
+            "failed": {},
+        }
+        mock.register(
+            "POST",
+            "https://api.zotero.org/users/myuserID/items",
+            body=json.dumps(prelim_response),
+            headers={"last-modified-version": "100"},
+        )
+
+        payload = [
+            {
+                "filename": "test_upload_file.txt",
+                "title": "Test File",
+                "linkMode": "imported_file",
+            }
+        ]
+        with (
+            patch.object(z.Zupload, "_verify", return_value=None),
+            patch.object(z.Zupload, "_get_auth", return_value={"exists": True}),
+        ):
+            upload = z.Zupload(zot, payload)
+            result = upload.upload()
+
+        self.assertEqual(result["unchanged"][0]["version"], 100)
+
     def testFileUploadWithParentItem(self):
         """Tests file upload process with a parent item ID"""
         mock = MockClient()


### PR DESCRIPTION
Description of changes:
`attachment_simple()` and `attachment_both()` returned the local payload templates with only the item `key` grafted on, so callers had no `version` to pass to a follow-up `update_item()` and had to refetch the item first.

The API supplies the version at every step, we just weren't capturing it: the creation response's `successful` dict contains the full saved objects (including `version`), and every write's `Last-Modified-Version` header carries the version that objects modified by that request were set to. `Zupload` now captures both — `_post_with_retry` tracks the header across steps, `_create_prelim` reads per-item versions from `successful` (header fallback), and each returned entry is stamped with the version from **its final write step**, because registering an upload (step 3) — and associating an already-existing file (step 1) — modifies the attachment again after creation, so the creation-time version alone would already be stale and a follow-up `update_item()` would 412.

No extra API calls are made. One known edge: for an `exists` file whose association is a server-side no-op, the stamped version may exceed the item's actual version (the header reflects the library version); `If-Unmodified-Since-Version` still passes in that case, it just slightly weakens the concurrency check for that one entry.

Tests cover the full-upload path (creation at version 100, registration bumps to 101 → entry carries 101) and the `exists` path (entry carries the creation version). The docs' note on the attachment methods' return type now mentions the `version` field.

**Held for verification:** to be confirmed against the live API before merging (the reporter's environment or a quick manual `attachment_simple()` + header/body dump), since this was verified against the API docs rather than a live write.

Issue reference (if applicable): Closes #354

- [x] I have read [the CONTRIBUTING doc](CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fD6npE2uyi9e33JQf5LBM

---
_Generated by [Claude Code](https://claude.ai/code/session_016fD6npE2uyi9e33JQf5LBM)_