### PR TITLE
Guard console scripts against a missing optional extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Versions reported by the local API are unrelated to web API versions, and are ty
 * Using [pip][10]: `pip install pyzotero`
 * Using Anaconda: `conda install conda-forge::pyzotero`
 
-Pyzotero also provides an optional [CLI](#command-line-interface) and [MCP server](#mcp-server) for working with a local Zotero library. Both require Zotero 7 with local API access enabled: Zotero > Settings > Advanced > "Allow other applications on this computer to communicate with Zotero". The CLI does not modify your library; its `authorize` command exists to obtain a local API key for granting write access to the MCP server. The MCP server is read-only by default, and needs that key only if started with `--enable-writes`.
+Pyzotero also provides an optional [CLI](#command-line-interface) and [MCP server](#mcp-server) for working with a local Zotero library. Both require Zotero 7 with local API access enabled: Zotero > Settings > Advanced > "Allow other applications on this computer to communicate with Zotero". The CLI does not modify your library; its `authorize` command exists to obtain a local API key for granting write access to the MCP server. The MCP server is read-only by default, and needs that key only if started with `--enable-writes`. Both console scripts are installed whichever extra you choose; one whose extra is missing exits with a message naming the extra to install.
 
 # Command-Line Interface
 
@@ -129,6 +129,7 @@ Pyzotero includes an optional [MCP](https://modelcontextprotocol.io) server that
 * Using [uv][11]: `uv add "pyzotero[mcp]"`
 * Using [pip][10]: `pip install "pyzotero[mcp]"`
 * As a standalone tool: `uv tool install "pyzotero[mcp]"`
+* CLI and MCP server together: `uv tool install "pyzotero[cli,mcp]"`
 
 ## Claude Desktop Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ cli = ["click>=8.0.0"]
 mcp = ["mcp[cli]>=1.0.0; python_version>='3.10'"]
 
 [project.scripts]
-pyzotero = "pyzotero.cli:main"
-pyzotero-mcp = "pyzotero.mcp_server:main"
+pyzotero = "pyzotero._entry:cli"
+pyzotero-mcp = "pyzotero._entry:mcp"
 
 [dependency-groups]
 dev = [

--- a/src/pyzotero/_entry.py
+++ b/src/pyzotero/_entry.py
@@ -1,0 +1,41 @@
+"""Console-script entry points.
+
+The CLI needs the ``cli`` extra and the MCP server needs the ``mcp`` extra,
+but ``[project.scripts]`` installs both scripts whichever extra is present.
+Each entry point checks for its extra before it imports the module that
+needs it, so that a missing extra ends in a short message and not in a
+traceback.
+"""
+
+from __future__ import annotations
+
+import sys
+from importlib.util import find_spec
+
+INSTALL_HINT = (
+    "pyzotero: {script} needs the '{extra}' extra, which is not installed.\n"
+    "Install it with:  pip install 'pyzotero[{extra}]'\n"
+    "or, as a tool:    uv tool install 'pyzotero[cli,mcp]'"
+)
+
+
+def _require(module: str, *, extra: str, script: str) -> None:
+    """Exit with an installation hint if ``module`` is not importable."""
+    if find_spec(module) is None:
+        sys.exit(INSTALL_HINT.format(script=script, extra=extra))
+
+
+def cli() -> None:
+    """Start the CLI after checking for the ``cli`` extra."""
+    _require("click", extra="cli", script="pyzotero")
+    from pyzotero.cli import main  # noqa: PLC0415
+
+    main()
+
+
+def mcp() -> None:
+    """Start the MCP server after checking for the ``mcp`` extra."""
+    _require("mcp", extra="mcp", script="pyzotero-mcp")
+    from pyzotero.mcp_server import main  # noqa: PLC0415
+
+    main()

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,0 +1,39 @@
+"""Tests for the console-script launchers in pyzotero._entry."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from pyzotero import _entry
+
+
+@pytest.mark.parametrize(
+    ("launcher", "script", "extra"),
+    [(_entry.cli, "pyzotero", "cli"), (_entry.mcp, "pyzotero-mcp", "mcp")],
+)
+def test_missing_extra_exits_with_hint(launcher, script, extra):
+    with (
+        patch("pyzotero._entry.find_spec", return_value=None),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        launcher()
+    message = str(excinfo.value)
+    assert script in message
+    assert f"pyzotero[{extra}]" in message
+    assert "pyzotero[cli,mcp]" in message
+
+
+def test_cli_delegates_when_extra_present():
+    pytest.importorskip("click")
+    with patch("pyzotero.cli.main") as main:
+        _entry.cli()
+    main.assert_called_once_with()
+
+
+def test_mcp_delegates_when_extra_present():
+    pytest.importorskip("mcp")
+    with patch("pyzotero.mcp_server.main") as main:
+        _entry.mcp()
+    main.assert_called_once_with()


### PR DESCRIPTION
Point both console scripts at `pyzotero._entry`, which checks that the extra the script needs is installed before importing the module, and exits with an installation hint otherwise.

`[project.scripts]` installs both `pyzotero` and `pyzotero-mcp` whichever extra is chosen, so running the one whose extra is missing produced an `ImportError` traceback. Now it prints a message naming the extra to install.

Closes #360

https://claude.ai/code/session_01JrhckdLFmG6YKfjjy7LYAB