### PR TITLE
Collection management from the CLI and the MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ The server is read-only unless started with `--enable-writes`.
 | `add_tags` | Add tags to an existing item |
 | `create_collection` | Create a collection, optionally nested |
 | `add_to_collection` | File an existing item under a collection |
+| `remove_from_collection` | Remove an item from a collection; the item itself is unchanged |
+| `move_to_collection` | Move an item from one collection to another in one step |
 | `add_attachment` | Attach a file on disk to an existing item |
 | `delete_item` | Permanently delete an item. Requires `--enable-deletes` |
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ pyzotero listcollections
 # List available item types
 pyzotero itemtypes
 
-# Obtain a local API key, for granting write access to the MCP server
+# Obtain and store a local API key, which permits writes from the CLI and the MCP server
 pyzotero authorize --app-name "Claude Desktop"
 ```
 
@@ -196,21 +196,22 @@ The server is read-only unless started with `--enable-writes`.
    pyzotero authorize --app-name "Claude Desktop"
    ```
 
-2. Pass the key in the server's environment, and add the `--enable-writes` flag:
+   The key and the Zotero server ID are stored in `$XDG_CONFIG_HOME/pyzotero/local-api-key.json` (`~/.config/pyzotero/local-api-key.json` if that variable is unset), readable only by you. The server reads the key from that file.
+
+2. Add the `--enable-writes` flag:
 
    ```json
    {
      "mcpServers": {
        "zotero": {
          "command": "pyzotero-mcp",
-         "args": ["--enable-writes"],
-         "env": { "PYZOTERO_LOCAL_API_KEY": "your-key-here" }
+         "args": ["--enable-writes"]
        }
      }
    }
    ```
 
-3. Optional: set `PYZOTERO_LOCAL_SERVER_ID` in the same `env` block to save one request at startup. Without it, the server fetches the ID automatically.
+3. Optional: to supply the key some other way, set `PYZOTERO_LOCAL_API_KEY` in the server's `env` block, and `PYZOTERO_LOCAL_SERVER_ID` beside it to save one request at startup. The environment takes precedence over the key file. `pyzotero authorize --no-store` prints a key without writing the file.
 
 #### Available write tools
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Versions reported by the local API are unrelated to web API versions, and are ty
 * Using [pip][10]: `pip install pyzotero`
 * Using Anaconda: `conda install conda-forge::pyzotero`
 
-Pyzotero also provides an optional [CLI](#command-line-interface) and [MCP server](#mcp-server) for working with a local Zotero library. Both require Zotero 7 with local API access enabled: Zotero > Settings > Advanced > "Allow other applications on this computer to communicate with Zotero". The CLI does not modify your library; its `authorize` command exists to obtain a local API key for granting write access to the MCP server. The MCP server is read-only by default, and needs that key only if started with `--enable-writes`. Both console scripts are installed whichever extra you choose; one whose extra is missing exits with a message naming the extra to install.
+Pyzotero also provides an optional [CLI](#command-line-interface) and [MCP server](#mcp-server) for working with a local Zotero library. Both require Zotero 7 with local API access enabled: Zotero > Settings > Advanced > "Allow other applications on this computer to communicate with Zotero". Both are read-only unless you run `pyzotero authorize`, which stores a local API key. With that key, the CLI's collection commands can write, and the MCP server can write if started with `--enable-writes`. Both console scripts are installed whichever extra you choose; one whose extra is missing exits with a message naming the extra to install.
 
 # Command-Line Interface
 
-Pyzotero includes an optional CLI for searching and querying your local Zotero library.
+Pyzotero includes an optional CLI for searching and querying your local Zotero library, and for managing its collections.
 
 ## Installing the CLI
 
@@ -103,7 +103,19 @@ pyzotero itemtypes
 
 # Obtain and store a local API key, which permits writes from the CLI and the MCP server
 pyzotero authorize --app-name "Claude Desktop"
+
+# Create a collection, nested under an existing one
+pyzotero createcollection "Frankenstein Cities" --parent FD9AUNP2
+
+# Add items to, remove items from, or move items between collections
+pyzotero addtocollection FD9AUNP2 ABC123 DEF456
+pyzotero removefromcollection FD9AUNP2 ABC123
+pyzotero movetocollection --from FD9AUNP2 --to X7Y8Z9W0 ABC123 DEF456
 ```
+
+## Collection Commands
+
+`createcollection`, `addtocollection`, `removefromcollection` and `movetocollection` write to your library. They need a stored local API key: run `pyzotero authorize` once and choose "Always Allow". Without a key, they exit with a message that says so. Each accepts `--json` and reports the keys it touched. The membership commands change items one at a time; if one fails, the error names the item and lists the items already changed, so that you can resume from there. `movetocollection` changes each item in one request, so an item's membership of other collections is kept.
 
 ## Search Behaviour
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1401,6 +1401,22 @@ Collection Methods
 
         See the :py:meth:`delete_item()` example for multiple-item removal.
 
+    .. py:method:: Zotero.moveto_collection(from_collection, to_collection, item)
+
+        Move the specified item from one collection to another, in a single request
+
+        :param str from_collection: the key of the collection to remove the item from
+        :param str to_collection: the key of the collection to add the item to
+        :param dict item: an item dict retrieved using an API call
+        :rtype: Boolean
+
+        The item's membership of other collections is unchanged. If the item is not in ``from_collection``, it is still added to ``to_collection``. Calling :py:meth:`deletefrom_collection()` followed by :py:meth:`addto_collection()` does not work for this: the first call changes the item's version, so the second call fails its version check.
+
+        .. code-block:: python
+
+            item = zot.item("ITEMKEY")
+            zot.moveto_collection("OLDCOLL", "NEWCOLL", item)
+
     .. py:method:: Zotero.update_collection(collection , last_modified])
 
         Update existing collection metadata (name etc.)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -56,7 +56,7 @@ Using `Anaconda <https://www.anaconda.com/distribution/>`_: ``conda install cond
 Optional: Command-Line Interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Pyzotero includes an optional command-line interface for searching and querying your local Zotero library.
+Pyzotero includes an optional command-line interface for searching and querying your local Zotero library, and for managing its collections.
 
 To install Pyzotero with the CLI:
 
@@ -100,7 +100,7 @@ Run ``pytest .`` from the top-level directory.
 Command-Line Interface Usage
 ----------------------------
 
-The Pyzotero CLI connects to your local Zotero installation and allows you to search your library, list collections, and view item types.
+The Pyzotero CLI connects to your local Zotero installation and allows you to search your library, list collections, view item types, and manage collection membership.
 
 Basic Commands
 ~~~~~~~~~~~~~~
@@ -200,6 +200,43 @@ List tags from a specific collection:
     .. code-block:: bash
 
         pyzotero tags --collection ABC123
+
+Collection Commands
+~~~~~~~~~~~~~~~~~~~
+
+These commands write to your library, so they need a local API key. Run ``pyzotero authorize`` once and choose "Always Allow" in Zotero's dialog. The key is stored in ``$XDG_CONFIG_HOME/pyzotero/local-api-key.json`` (``~/.config/pyzotero/local-api-key.json`` if that variable is unset), readable only by you. Setting ``PYZOTERO_LOCAL_API_KEY`` in the environment takes precedence over the file. Without a key, the commands exit with a message that says so.
+
+Obtain and store a key:
+
+    .. code-block:: bash
+
+        pyzotero authorize --app-name "My tool"
+
+Create a collection, at the top level or nested under ``--parent``:
+
+    .. code-block:: bash
+
+        pyzotero createcollection "Frankenstein Cities" --parent FD9AUNP2
+
+Add items to a collection:
+
+    .. code-block:: bash
+
+        pyzotero addtocollection FD9AUNP2 ABC123 DEF456
+
+Remove items from a collection (the items themselves are unchanged):
+
+    .. code-block:: bash
+
+        pyzotero removefromcollection FD9AUNP2 ABC123
+
+Move items from one collection to another:
+
+    .. code-block:: bash
+
+        pyzotero movetocollection --from FD9AUNP2 --to X7Y8Z9W0 ABC123 DEF456
+
+Each command accepts ``--json`` and reports the keys it touched. The membership commands change items one at a time. If one fails, the error names that item and lists the items already changed, so that you can resume. ``movetocollection`` changes each item in one request: its membership of other collections is kept.
 
 DOI Index
 ~~~~~~~~~

--- a/src/pyzotero/_client.py
+++ b/src/pyzotero/_client.py
@@ -1502,6 +1502,25 @@ class Zotero:
         """
         return self._batch_update(payload, "collections", last_modified)
 
+    def _patch_collections(
+        self, payload: dict[str, Any], collections: list[str]
+    ) -> httpx2.Response:
+        """Replace the collection list of one item with ``collections``.
+
+        ``payload`` is an item dict from the API. Its ``version`` becomes the
+        If-Unmodified-Since-Version precondition.
+        """
+        headers = {"If-Unmodified-Since-Version": str(payload["version"])}
+        return self._write(
+            "PATCH",
+            url=build_url(
+                self.endpoint,
+                f"/{self.library_type}/{self.library_id}/items/{payload['key']}",
+            ),
+            json={"collections": collections},
+            headers=headers,
+        )
+
     @backoff_check
     def addto_collection(
         self, collection: str, payload: dict[str, Any]
@@ -1510,20 +1529,9 @@ class Zotero:
 
         Accepts two arguments: The collection ID, and an item dict.
         """
-        ident = payload["key"]
-        modified = payload["version"]
         # add the collection data from the item
         modified_collections = payload["data"]["collections"] + [collection]
-        headers = {"If-Unmodified-Since-Version": str(modified)}
-        return self._write(
-            "PATCH",
-            url=build_url(
-                self.endpoint,
-                f"/{self.library_type}/{self.library_id}/items/{ident}",
-            ),
-            json={"collections": modified_collections},
-            headers=headers,
-        )
+        return self._patch_collections(payload, modified_collections)
 
     @backoff_check
     def deletefrom_collection(
@@ -1533,22 +1541,33 @@ class Zotero:
 
         Accepts two arguments: The collection ID, and an item dict.
         """
-        ident = payload["key"]
-        modified = payload["version"]
         # strip the collection data from the item
         modified_collections = [
             c for c in payload["data"]["collections"] if c != collection
         ]
-        headers = {"If-Unmodified-Since-Version": str(modified)}
-        return self._write(
-            "PATCH",
-            url=build_url(
-                self.endpoint,
-                f"/{self.library_type}/{self.library_id}/items/{ident}",
-            ),
-            json={"collections": modified_collections},
-            headers=headers,
-        )
+        return self._patch_collections(payload, modified_collections)
+
+    @backoff_check
+    def moveto_collection(
+        self, from_collection: str, to_collection: str, payload: dict[str, Any]
+    ) -> httpx2.Response:
+        """Move an item from one collection to another.
+
+        Accepts three arguments: the source collection ID, the destination
+        collection ID, and an item dict. This is one request, unlike a
+        :meth:`deletefrom_collection` call followed by an
+        :meth:`addto_collection` call: the second of those would fail its
+        version precondition. Membership of other collections is unchanged.
+        If the item is not in the source collection, it is added to the
+        destination collection all the same.
+        """
+        modified_collections = [
+            c
+            for c in payload["data"]["collections"]
+            if c not in (from_collection, to_collection)
+        ]
+        modified_collections.append(to_collection)
+        return self._patch_collections(payload, modified_collections)
 
     @backoff_check
     def delete_tags(self, *payload: str) -> httpx2.Response:

--- a/src/pyzotero/_helpers.py
+++ b/src/pyzotero/_helpers.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import json
+import os
+import stat
+from pathlib import Path
 from typing import Any
 
 from pyzotero import zotero
+
+LOCAL_KEY_ENV = "PYZOTERO_LOCAL_API_KEY"
+LOCAL_SERVER_ID_ENV = "PYZOTERO_LOCAL_SERVER_ID"
 
 
 def get_zotero_client(
@@ -14,11 +21,11 @@ def get_zotero_client(
 ) -> zotero.Zotero:
     """Get a Zotero client that is configured for local access.
 
-    The CLI and the MCP server are read-only, so they do not use the two
-    optional arguments. The arguments let other callers write:
+    Without the two optional arguments the client can only read.
     ``local_api_key`` permits writes (see :meth:`Zotero.authorize_local`),
     and ``server_id`` supplies a server ID that was kept from an earlier
-    session, which prevents one initial request.
+    session, which prevents one initial request. :func:`get_write_client`
+    fills both in from the stored key.
     """
     return zotero.Zotero(
         library_id="0",
@@ -28,6 +35,69 @@ def get_zotero_client(
         server_id=server_id,
         local_api_key=local_api_key,
     )
+
+
+def local_key_path() -> Path:
+    """Return the path of the file that holds a stored local API key.
+
+    The file is ``pyzotero/local-api-key.json`` under ``$XDG_CONFIG_HOME``,
+    or under ``~/.config`` if that variable is not set.
+    """
+    base = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    return Path(base) / "pyzotero" / "local-api-key.json"
+
+
+def load_local_key() -> tuple[str | None, str | None]:
+    """Return ``(server_id, key)`` for local writes.
+
+    The environment variables ``PYZOTERO_LOCAL_API_KEY`` and
+    ``PYZOTERO_LOCAL_SERVER_ID`` take precedence. If the key variable is not
+    set, the key file from :func:`local_key_path` supplies both values. Each
+    value is None if no source supplies it.
+    """
+    key = os.environ.get(LOCAL_KEY_ENV)
+    if key:
+        return os.environ.get(LOCAL_SERVER_ID_ENV) or None, key
+    try:
+        data = json.loads(local_key_path().read_text())
+    except (OSError, ValueError):
+        return None, None
+    if not isinstance(data, dict):
+        return None, None
+    return data.get("server_id") or None, data.get("key") or None
+
+
+def save_local_key(key: str, server_id: str | None) -> Path:
+    """Write ``key`` and ``server_id`` to the key file. Return its path.
+
+    The file gets mode 0600, so that only the user can read it.
+    """
+    path = local_key_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"server_id": server_id, "key": key}, indent=2) + "\n")
+    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    return path
+
+
+def get_write_client(locale: str = "en-US") -> zotero.Zotero:
+    """Get a local client that can write, using the stored local API key.
+
+    This function does not request a key itself. The MCP client starts and
+    restarts the server, so a request at startup would show a Zotero dialog
+    with no clear cause. Run ``pyzotero authorize`` to get a permanent key.
+
+    Raises:
+        RuntimeError: No key is stored and none is set in the environment.
+
+    """
+    server_id, key = load_local_key()
+    if not key:
+        msg = (
+            "No local API key. Run 'pyzotero authorize' and choose 'Always Allow' "
+            f"so that the key persists, or set {LOCAL_KEY_ENV} in the environment."
+        )
+        raise RuntimeError(msg)
+    return get_zotero_client(locale, server_id=server_id, local_api_key=key)
 
 
 def normalise_doi(doi: str) -> str:

--- a/src/pyzotero/cli.py
+++ b/src/pyzotero/cli.py
@@ -20,6 +20,7 @@ from pyzotero._helpers import (
     format_s2_paper,
     get_zotero_client,
     normalise_doi,
+    save_local_key,
 )
 from pyzotero.semantic_scholar import (
     PaperNotFoundError,
@@ -458,20 +459,32 @@ def itemtypes(ctx: Any) -> None:
     show_default=True,
     help="The name that Zotero shows in the authorisation dialog.",
 )
+@click.option(
+    "--no-store",
+    is_flag=True,
+    help="Print the key only. Do not write it to the key file.",
+)
 @click.pass_context
 @cli_error_handler
-def authorize(ctx: Any, app_name: str) -> None:
+def authorize(ctx: Any, app_name: str, no_store: bool) -> None:
     """Get a local API key, which permits writes to your Zotero library.
 
     Zotero shows a dialog with the options "Allow" (one-time access),
     "Always Allow" (permanent access) and "Deny". Select "Always Allow" to
     get a key that you can keep: the first write uses a one-time key.
 
+    A permanent key is stored in a file that only you can read
+    ($XDG_CONFIG_HOME/pyzotero/local-api-key.json, or the same path under
+    ~/.config). The CLI's collection commands and the MCP server, when
+    started with --enable-writes, read the key from that file. Setting
+    PYZOTERO_LOCAL_API_KEY in the environment takes precedence over it.
+
     Local API keys have no relation to zotero.org API keys.
 
     Examples:
         pyzotero authorize
         pyzotero authorize --app-name "My MCP server"
+        pyzotero authorize --no-store
 
     """
     zot = _zot_from_ctx(ctx)
@@ -479,7 +492,14 @@ def authorize(ctx: Any, app_name: str) -> None:
     result = zot.authorize_local(app_name)
     click.echo(f"Key:       {result['key']}")
     click.echo(f"Server ID: {zot.server_id}")
-    if result["remember"]:
+    if not result["remember"]:
+        click.echo(
+            "\nThis key is single-use: the first successful write consumes it.\n"
+            "Re-run and choose 'Always Allow' if you need a persistent key.",
+            err=True,
+        )
+        return
+    if no_store:
         click.echo(
             "\nThis key persists. To give the MCP server write access, set it in\n"
             "the server's environment and pass --enable-writes:\n\n"
@@ -487,12 +507,14 @@ def authorize(ctx: Any, app_name: str) -> None:
             '    "args": ["--enable-writes"]',
             err=True,
         )
-    else:
-        click.echo(
-            "\nThis key is single-use: the first successful write consumes it.\n"
-            "Re-run and choose 'Always Allow' if you need a persistent key.",
-            err=True,
-        )
+        return
+    path = save_local_key(result["key"], zot.server_id)
+    click.echo(
+        f"\nThis key persists. Stored it in {path}.\n"
+        "The CLI's collection commands use it. So does the MCP server when\n"
+        "started with --enable-writes; no environment variable is needed.",
+        err=True,
+    )
 
 
 @main.command()

--- a/src/pyzotero/cli.py
+++ b/src/pyzotero/cli.py
@@ -18,6 +18,7 @@ from pyzotero._helpers import (
     build_doi_index_full,
     format_creators,
     format_s2_paper,
+    get_write_client,
     get_zotero_client,
     normalise_doi,
     save_local_key,
@@ -71,6 +72,37 @@ def _zot_from_ctx(ctx: Any) -> Any:
     return get_zotero_client(ctx.obj.get("locale", "en-US"))
 
 
+def _write_zot_from_ctx(ctx: Any) -> Any:
+    """Build a local-mode client that can write, from the stored local API key.
+
+    Raises RuntimeError, which the error handler reports, if no key is stored.
+    """
+    return get_write_client(ctx.obj.get("locale", "en-US"))
+
+
+def _change_membership(
+    zot: Any, keys: tuple[str, ...], change: Callable[[dict[str, Any]], Any]
+) -> list[str]:
+    """Fetch each item in ``keys`` and apply ``change`` to it. Return the keys.
+
+    The items change one at a time. If one fails, the error names it and
+    lists the items that had already changed, so that the caller can resume.
+    """
+    done: list[str] = []
+    for key in keys:
+        try:
+            change(zot.item(key))
+        except Exception as exc:
+            changed = ", ".join(done) if done else "none"
+            msg = (
+                f"{key}: {exc} "
+                f"(changed {len(done)} of {len(keys)} items before this: {changed})"
+            )
+            raise RuntimeError(msg) from exc
+        done.append(key)
+    return done
+
+
 def _run_s2_lookup(
     ctx: Any,
     doi: str,
@@ -120,7 +152,7 @@ def _run_s2_lookup(
 )
 @click.pass_context
 def main(ctx: Any, locale: str) -> None:
-    """Search local Zotero library."""
+    """Search and manage a local Zotero library."""
     ctx.ensure_object(dict)
     ctx.obj["locale"] = locale
 
@@ -515,6 +547,188 @@ def authorize(ctx: Any, app_name: str, no_store: bool) -> None:
         "started with --enable-writes; no environment variable is needed.",
         err=True,
     )
+
+
+@main.command()
+@click.argument("name")
+@click.option(
+    "--parent",
+    help="Key of the parent collection. The new collection nests under it.",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output results as JSON",
+)
+@click.pass_context
+@cli_error_handler
+def createcollection(
+    ctx: Any, name: str, parent: str | None, output_json: bool
+) -> None:
+    """Create a collection, at the top level or under --parent.
+
+    Needs a stored local API key: run 'pyzotero authorize' first.
+
+    Examples:
+        pyzotero createcollection "Frankenstein Cities"
+
+        pyzotero createcollection "Frankenstein Cities" --parent FD9AUNP2 --json
+
+    """
+    zot = _write_zot_from_ctx(ctx)
+    payload: dict[str, Any] = {"name": name}
+    if parent:
+        payload["parentCollection"] = parent
+    resp = zot.create_collections([payload])
+    if not resp.get("success"):
+        msg = f"Collection was rejected: {resp.get('failed')}"
+        raise RuntimeError(msg)
+    key = resp["success"]["0"]
+    if output_json:
+        click.echo(
+            json.dumps(
+                {"created": key, "name": name, "parent": parent or None}, indent=2
+            )
+        )
+    else:
+        where = f" under {parent}" if parent else ""
+        click.echo(f"Created collection {name!r} with key {key}{where}")
+
+
+@main.command()
+@click.argument("collection_key")
+@click.argument("item_keys", nargs=-1, required=True)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output results as JSON",
+)
+@click.pass_context
+@cli_error_handler
+def addtocollection(
+    ctx: Any, collection_key: str, item_keys: tuple[str, ...], output_json: bool
+) -> None:
+    """Add one or more items to a collection.
+
+    Needs a stored local API key: run 'pyzotero authorize' first.
+
+    Examples:
+        pyzotero addtocollection FD9AUNP2 ABC123 DEF456
+
+        pyzotero addtocollection FD9AUNP2 ABC123 --json
+
+    """
+    zot = _write_zot_from_ctx(ctx)
+    done = _change_membership(
+        zot, item_keys, lambda item: zot.addto_collection(collection_key, item)
+    )
+    if output_json:
+        click.echo(json.dumps({"collection": collection_key, "added": done}, indent=2))
+    else:
+        click.echo(f"Added {len(done)} items to {collection_key}: {', '.join(done)}")
+
+
+@main.command()
+@click.argument("collection_key")
+@click.argument("item_keys", nargs=-1, required=True)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output results as JSON",
+)
+@click.pass_context
+@cli_error_handler
+def removefromcollection(
+    ctx: Any, collection_key: str, item_keys: tuple[str, ...], output_json: bool
+) -> None:
+    """Remove one or more items from a collection. The items are unchanged.
+
+    Needs a stored local API key: run 'pyzotero authorize' first.
+
+    Examples:
+        pyzotero removefromcollection FD9AUNP2 ABC123 DEF456
+
+        pyzotero removefromcollection FD9AUNP2 ABC123 --json
+
+    """
+    zot = _write_zot_from_ctx(ctx)
+    done = _change_membership(
+        zot, item_keys, lambda item: zot.deletefrom_collection(collection_key, item)
+    )
+    if output_json:
+        click.echo(
+            json.dumps({"collection": collection_key, "removed": done}, indent=2)
+        )
+    else:
+        click.echo(
+            f"Removed {len(done)} items from {collection_key}: {', '.join(done)}"
+        )
+
+
+@main.command()
+@click.argument("item_keys", nargs=-1, required=True)
+@click.option(
+    "--from",
+    "from_collection",
+    required=True,
+    help="Key of the collection to remove the items from",
+)
+@click.option(
+    "--to",
+    "to_collection",
+    required=True,
+    help="Key of the collection to add the items to",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output results as JSON",
+)
+@click.pass_context
+@cli_error_handler
+def movetocollection(
+    ctx: Any,
+    item_keys: tuple[str, ...],
+    from_collection: str,
+    to_collection: str,
+    output_json: bool,
+) -> None:
+    """Move one or more items from one collection to another.
+
+    Each item leaves the --from collection and joins the --to collection in
+    one request. Membership of other collections is unchanged. An item that
+    is not in the --from collection still joins the --to collection.
+
+    Needs a stored local API key: run 'pyzotero authorize' first.
+
+    Examples:
+        pyzotero movetocollection --from FD9AUNP2 --to X7Y8Z9W0 ABC123 DEF456
+
+        pyzotero movetocollection --from FD9AUNP2 --to X7Y8Z9W0 ABC123 --json
+
+    """
+    zot = _write_zot_from_ctx(ctx)
+    done = _change_membership(
+        zot,
+        item_keys,
+        lambda item: zot.moveto_collection(from_collection, to_collection, item),
+    )
+    if output_json:
+        click.echo(
+            json.dumps(
+                {"from": from_collection, "to": to_collection, "moved": done},
+                indent=2,
+            )
+        )
+    else:
+        click.echo(
+            f"Moved {len(done)} items from {from_collection} to {to_collection}: "
+            f"{', '.join(done)}"
+        )
 
 
 @main.command()

--- a/src/pyzotero/mcp_server.py
+++ b/src/pyzotero/mcp_server.py
@@ -587,7 +587,7 @@ def _register_item_tools(add: AddTool) -> None:
 
 
 def _register_collection_tools(add: AddTool) -> None:
-    """Register tools that create collections and file items into them."""
+    """Register tools that create collections and change item membership."""
 
     def create_collection(name: str, parent: str = "") -> str:
         """Create a new collection.
@@ -624,7 +624,61 @@ def _register_collection_tools(add: AddTool) -> None:
         zot.addto_collection(collection_key, zot.item(item_key))
         return _json({"item": item_key, "addedTo": collection_key})
 
-    for tool in (create_collection, add_to_collection):
+    def remove_from_collection(item_key: str, collection_key: str) -> str:
+        """Remove an item from a collection. The item itself is unchanged.
+
+        This is the inverse of add_to_collection. The item stays in the
+        library and in its other collections.
+
+        Args:
+            item_key: The item key.
+            collection_key: The collection key.
+
+        Returns:
+            JSON confirming the item and collection.
+
+        """
+        zot = _write_client()
+        zot.deletefrom_collection(collection_key, zot.item(item_key))
+        return _json({"item": item_key, "removedFrom": collection_key})
+
+    def move_to_collection(
+        item_key: str, from_collection_key: str, to_collection_key: str
+    ) -> str:
+        """Move an item from one collection to another in one step.
+
+        Prefer this over get_item followed by update_item with a rewritten
+        collections list: membership of other collections is kept. If the
+        item is not in the source collection, it is added to the destination
+        all the same.
+
+        Args:
+            item_key: The item key.
+            from_collection_key: The key of the collection to remove the item from.
+            to_collection_key: The key of the collection to add the item to.
+
+        Returns:
+            JSON confirming the item, the source and the destination.
+
+        """
+        zot = _write_client()
+        zot.moveto_collection(
+            from_collection_key, to_collection_key, zot.item(item_key)
+        )
+        return _json(
+            {
+                "item": item_key,
+                "movedFrom": from_collection_key,
+                "movedTo": to_collection_key,
+            }
+        )
+
+    for tool in (
+        create_collection,
+        add_to_collection,
+        remove_from_collection,
+        move_to_collection,
+    ):
         add(tool)
 
 

--- a/src/pyzotero/mcp_server.py
+++ b/src/pyzotero/mcp_server.py
@@ -6,7 +6,6 @@ import argparse
 import functools
 import hashlib
 import json
-import os
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -15,10 +14,13 @@ from typing import Any, TypeVar
 from mcp.server.fastmcp import FastMCP
 
 from pyzotero._helpers import (
+    LOCAL_KEY_ENV,
+    LOCAL_SERVER_ID_ENV,
     annotate_with_library,
     build_doi_index,
     format_creators,
     format_s2_paper,
+    get_write_client,
     get_zotero_client,
 )
 from pyzotero.semantic_scholar import (
@@ -465,31 +467,17 @@ def search_semantic_scholar(
     return _json({"count": len(output_papers), "total": total, "papers": output_papers})
 
 
-WRITE_KEY_ENV = "PYZOTERO_LOCAL_API_KEY"
-SERVER_ID_ENV = "PYZOTERO_LOCAL_SERVER_ID"
+WRITE_KEY_ENV = LOCAL_KEY_ENV
+SERVER_ID_ENV = LOCAL_SERVER_ID_ENV
 
 
 def _write_client() -> Any:
     """Return a Zotero client that has write access to the local API.
 
-    The key comes from the environment. This function does not request one
-    itself: the MCP client starts and restarts this server, so a request at
-    startup would show a Zotero dialog with no clear cause, and would fail if
-    Zotero were not running. Run ``pyzotero authorize`` to get a permanent
-    key.
+    The key comes from the environment, or else from the file that
+    ``pyzotero authorize`` writes. See :func:`get_write_client`.
     """
-    key = os.environ.get(WRITE_KEY_ENV)
-    if not key:
-        msg = (
-            f"No local API key: set {WRITE_KEY_ENV} in this server's environment. "
-            "Run 'pyzotero authorize' to obtain one, choosing 'Always Allow' so "
-            "that the key persists."
-        )
-        raise RuntimeError(msg)
-    return get_zotero_client(
-        server_id=os.environ.get(SERVER_ID_ENV) or None,
-        local_api_key=key,
-    )
+    return get_write_client()
 
 
 AddTool = Callable[[Callable[..., str]], None]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,202 @@
+"""Tests for the CLI write commands (#361)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("click")
+
+from click.testing import CliRunner
+
+from pyzotero import cli
+from pyzotero._helpers import local_key_path
+
+
+USAGE_ERROR = 2  # click's exit code for bad arguments
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("PYZOTERO_LOCAL_API_KEY", raising=False)
+    monkeypatch.delenv("PYZOTERO_LOCAL_SERVER_ID", raising=False)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def write_zot():
+    """Patch get_write_client to return a mock, and return the mock."""
+    mock = MagicMock()
+    mock.create_collections.return_value = {"success": {"0": "NEWCOLL"}, "failed": {}}
+    mock.item.side_effect = lambda key: {
+        "key": key,
+        "version": 3,
+        "data": {"key": key, "version": 3, "collections": ["OLD"]},
+    }
+    with patch("pyzotero.cli.get_write_client", return_value=mock):
+        yield mock
+
+
+class TestKeyGate:
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["createcollection", "Name"],
+            ["addtocollection", "COLL", "ABC123"],
+            ["removefromcollection", "COLL", "ABC123"],
+            ["movetocollection", "--from", "A", "--to", "B", "ABC123"],
+        ],
+    )
+    def test_refuses_without_key(self, runner, args):
+        result = runner.invoke(cli.main, args)
+        assert result.exit_code == 1
+        assert "pyzotero authorize" in result.output
+
+    def test_locale_reaches_write_client(self, runner, write_zot):
+        with patch("pyzotero.cli.get_write_client", return_value=write_zot) as gwc:
+            runner.invoke(cli.main, ["--locale", "de-DE", "createcollection", "N"])
+        gwc.assert_called_once_with("de-DE")
+
+
+class TestCreateCollection:
+    def test_top_level(self, runner, write_zot):
+        result = runner.invoke(cli.main, ["createcollection", "Top"])
+        assert result.exit_code == 0, result.output
+        assert "NEWCOLL" in result.output
+        assert write_zot.create_collections.call_args[0][0] == [{"name": "Top"}]
+
+    def test_nested_json(self, runner, write_zot):
+        result = runner.invoke(
+            cli.main, ["createcollection", "Kids", "--parent", "PARENT1", "--json"]
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {
+            "created": "NEWCOLL",
+            "name": "Kids",
+            "parent": "PARENT1",
+        }
+        assert write_zot.create_collections.call_args[0][0] == [
+            {"name": "Kids", "parentCollection": "PARENT1"}
+        ]
+
+    def test_rejection_is_an_error(self, runner, write_zot):
+        write_zot.create_collections.return_value = {
+            "success": {},
+            "failed": {"0": {"code": 400, "message": "Bad name"}},
+        }
+        result = runner.invoke(cli.main, ["createcollection", "Bad"])
+        assert result.exit_code == 1
+        assert "Bad name" in result.output
+
+
+class TestMembership:
+    def test_add_many(self, runner, write_zot):
+        result = runner.invoke(
+            cli.main, ["addtocollection", "COLL1", "ABC123", "DEF456", "--json"]
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {
+            "collection": "COLL1",
+            "added": ["ABC123", "DEF456"],
+        }
+        calls = write_zot.addto_collection.call_args_list
+        assert [c[0][0] for c in calls] == ["COLL1", "COLL1"]
+        assert [c[0][1]["key"] for c in calls] == ["ABC123", "DEF456"]
+
+    def test_add_text_output(self, runner, write_zot):
+        result = runner.invoke(cli.main, ["addtocollection", "COLL1", "ABC123"])
+        assert result.exit_code == 0, result.output
+        assert "Added 1 items to COLL1: ABC123" in result.output
+
+    def test_remove(self, runner, write_zot):
+        result = runner.invoke(
+            cli.main, ["removefromcollection", "COLL1", "ABC123", "--json"]
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {
+            "collection": "COLL1",
+            "removed": ["ABC123"],
+        }
+        args = write_zot.deletefrom_collection.call_args[0]
+        assert args[0] == "COLL1"
+        assert args[1]["key"] == "ABC123"
+
+    def test_move(self, runner, write_zot):
+        result = runner.invoke(
+            cli.main,
+            ["movetocollection", "--from", "OLD", "--to", "NEW", "ABC123", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {
+            "from": "OLD",
+            "to": "NEW",
+            "moved": ["ABC123"],
+        }
+        args = write_zot.moveto_collection.call_args[0]
+        assert args[:2] == ("OLD", "NEW")
+        assert args[2]["key"] == "ABC123"
+
+    def test_move_requires_both_collections(self, runner, write_zot):
+        result = runner.invoke(cli.main, ["movetocollection", "--from", "OLD", "ABC"])
+        assert result.exit_code == USAGE_ERROR
+        assert "--to" in result.output
+
+    def test_requires_at_least_one_item(self, runner, write_zot):
+        result = runner.invoke(cli.main, ["addtocollection", "COLL1"])
+        assert result.exit_code == USAGE_ERROR
+
+    def test_failure_names_item_and_progress(self, runner, write_zot):
+        """A batch stops at the first failure and reports what is already done"""
+        write_zot.addto_collection.side_effect = [None, RuntimeError("boom"), None]
+        result = runner.invoke(
+            cli.main, ["addtocollection", "COLL1", "AAA", "BBB", "CCC"]
+        )
+        assert result.exit_code == 1
+        assert "BBB: boom" in result.output
+        assert "changed 1 of 3 items" in result.output
+        assert "AAA" in result.output
+        # the third item is not attempted
+        assert write_zot.addto_collection.call_count == len(["AAA", "BBB"])
+
+
+class TestAuthorize:
+    @pytest.fixture
+    def read_zot(self):
+        mock = MagicMock()
+        mock.server_id = "srv1"
+        with patch("pyzotero.cli.get_zotero_client", return_value=mock):
+            yield mock
+
+    def test_persistent_key_is_stored(self, runner, read_zot):
+        read_zot.authorize_local.return_value = {"key": "abc123", "remember": True}
+        result = runner.invoke(cli.main, ["authorize"])
+        assert result.exit_code == 0, result.output
+        path = local_key_path()
+        assert json.loads(path.read_text()) == {"server_id": "srv1", "key": "abc123"}
+        assert str(path) in result.output
+
+    def test_no_store_flag(self, runner, read_zot):
+        read_zot.authorize_local.return_value = {"key": "abc123", "remember": True}
+        result = runner.invoke(cli.main, ["authorize", "--no-store"])
+        assert result.exit_code == 0, result.output
+        assert not local_key_path().exists()
+        assert "PYZOTERO_LOCAL_API_KEY" in result.output
+
+    def test_single_use_key_is_not_stored(self, runner, read_zot):
+        read_zot.authorize_local.return_value = {"key": "once", "remember": False}
+        result = runner.invoke(cli.main, ["authorize"])
+        assert result.exit_code == 0, result.output
+        assert not local_key_path().exists()
+        assert "single-use" in result.output
+
+    def test_app_name_passed_through(self, runner, read_zot):
+        read_zot.authorize_local.return_value = {"key": "k", "remember": True}
+        runner.invoke(cli.main, ["authorize", "--app-name", "My tool"])
+        read_zot.authorize_local.assert_called_once_with("My tool")

--- a/tests/test_local_key.py
+++ b/tests/test_local_key.py
@@ -1,0 +1,85 @@
+"""Tests for the stored local API key (#361, #362)."""
+
+from __future__ import annotations
+
+import json
+import stat
+from unittest.mock import patch
+
+import pytest
+
+from pyzotero import _helpers
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv(_helpers.LOCAL_KEY_ENV, raising=False)
+    monkeypatch.delenv(_helpers.LOCAL_SERVER_ID_ENV, raising=False)
+    return tmp_path
+
+
+class TestKeyPath:
+    def test_under_xdg_config_home(self, tmp_path):
+        assert _helpers.local_key_path() == (
+            tmp_path / "pyzotero" / "local-api-key.json"
+        )
+
+    def test_falls_back_to_dot_config(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("XDG_CONFIG_HOME")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert _helpers.local_key_path() == (
+            tmp_path / ".config" / "pyzotero" / "local-api-key.json"
+        )
+
+
+class TestSaveAndLoad:
+    def test_round_trip(self):
+        path = _helpers.save_local_key("abc123", "srv1")
+        assert path == _helpers.local_key_path()
+        assert json.loads(path.read_text()) == {"server_id": "srv1", "key": "abc123"}
+        assert _helpers.load_local_key() == ("srv1", "abc123")
+
+    def test_file_is_private(self):
+        path = _helpers.save_local_key("abc123", None)
+        assert stat.S_IMODE(path.stat().st_mode) == stat.S_IRUSR | stat.S_IWUSR
+
+    def test_missing_server_id_is_none(self):
+        _helpers.save_local_key("abc123", None)
+        assert _helpers.load_local_key() == (None, "abc123")
+
+    def test_no_file(self):
+        assert _helpers.load_local_key() == (None, None)
+
+    def test_corrupt_file(self):
+        path = _helpers.local_key_path()
+        path.parent.mkdir(parents=True)
+        path.write_text("not json")
+        assert _helpers.load_local_key() == (None, None)
+
+    def test_wrong_shape(self):
+        path = _helpers.local_key_path()
+        path.parent.mkdir(parents=True)
+        path.write_text("[1, 2]")
+        assert _helpers.load_local_key() == (None, None)
+
+    def test_env_overrides_file(self, monkeypatch):
+        _helpers.save_local_key("filekey", "filesrv")
+        monkeypatch.setenv(_helpers.LOCAL_KEY_ENV, "envkey")
+        assert _helpers.load_local_key() == (None, "envkey")
+        monkeypatch.setenv(_helpers.LOCAL_SERVER_ID_ENV, "envsrv")
+        assert _helpers.load_local_key() == ("envsrv", "envkey")
+
+
+class TestWriteClient:
+    def test_no_key_names_the_remedy(self):
+        with pytest.raises(RuntimeError, match="pyzotero authorize"):
+            _helpers.get_write_client()
+
+    def test_stored_key_is_used(self):
+        _helpers.save_local_key("abc123", "srv1")
+        with patch("pyzotero._helpers.get_zotero_client") as client:
+            _helpers.get_write_client(locale="de-DE")
+        client.assert_called_once_with(
+            "de-DE", server_id="srv1", local_api_key="abc123"
+        )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -459,6 +459,8 @@ class TestWriteGating:
         server = _FakeServer()
         names = mcp_server.register_write_tools(server)
         assert "create_item" in names
+        assert "remove_from_collection" in names
+        assert "move_to_collection" in names
         assert "delete_item" not in names
         assert "delete_item" not in server.tools
 
@@ -577,6 +579,20 @@ class TestWriteTools:
         args = write_zot.addto_collection.call_args[0]
         assert args[0] == "COLL1"
         assert args[1]["key"] == "ABC123"
+
+    def test_remove_from_collection(self, write_tools, write_zot):
+        result = json.loads(write_tools["remove_from_collection"]("ABC123", "COLL1"))
+        assert result == {"item": "ABC123", "removedFrom": "COLL1"}
+        args = write_zot.deletefrom_collection.call_args[0]
+        assert args[0] == "COLL1"
+        assert args[1]["key"] == "ABC123"
+
+    def test_move_to_collection(self, write_tools, write_zot):
+        result = json.loads(write_tools["move_to_collection"]("ABC123", "OLD", "NEW"))
+        assert result == {"item": "ABC123", "movedFrom": "OLD", "movedTo": "NEW"}
+        args = write_zot.moveto_collection.call_args[0]
+        assert args[:2] == ("OLD", "NEW")
+        assert args[2]["key"] == "ABC123"
 
     def test_delete_item(self, write_tools, write_zot):
         result = json.loads(write_tools["delete_item"]("ABC123"))

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from pyzotero._helpers import save_local_key
+
 
 # The mcp extra requires Python >= 3.10, so skip the entire module on older versions
 mcp_server = pytest.importorskip(
@@ -473,24 +475,47 @@ class TestWriteGating:
 
 
 class TestWriteClient:
-    def test_missing_key_raises_with_remedy(self, monkeypatch):
+    @pytest.fixture(autouse=True)
+    def _no_stored_key(self, monkeypatch, tmp_path):
+        """Point the key file at an empty directory, whatever the user has"""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.delenv(mcp_server.WRITE_KEY_ENV, raising=False)
+        monkeypatch.delenv(mcp_server.SERVER_ID_ENV, raising=False)
+
+    def test_missing_key_raises_with_remedy(self):
         with pytest.raises(RuntimeError, match="pyzotero authorize"):
             mcp_server._write_client()
 
     def test_key_and_server_id_passed_through(self, monkeypatch):
         monkeypatch.setenv(mcp_server.WRITE_KEY_ENV, "key123")
         monkeypatch.setenv(mcp_server.SERVER_ID_ENV, "srv123")
-        with patch("pyzotero.mcp_server.get_zotero_client") as client:
+        with patch("pyzotero._helpers.get_zotero_client") as client:
             mcp_server._write_client()
-        client.assert_called_once_with(server_id="srv123", local_api_key="key123")
+        client.assert_called_once_with(
+            "en-US", server_id="srv123", local_api_key="key123"
+        )
 
     def test_absent_server_id_is_none(self, monkeypatch):
         monkeypatch.setenv(mcp_server.WRITE_KEY_ENV, "key123")
-        monkeypatch.delenv(mcp_server.SERVER_ID_ENV, raising=False)
-        with patch("pyzotero.mcp_server.get_zotero_client") as client:
+        with patch("pyzotero._helpers.get_zotero_client") as client:
             mcp_server._write_client()
-        client.assert_called_once_with(server_id=None, local_api_key="key123")
+        client.assert_called_once_with("en-US", server_id=None, local_api_key="key123")
+
+    def test_key_file_used_when_env_absent(self):
+        """The file that 'pyzotero authorize' writes serves the MCP server too"""
+        save_local_key("filekey", "filesrv")
+        with patch("pyzotero._helpers.get_zotero_client") as client:
+            mcp_server._write_client()
+        client.assert_called_once_with(
+            "en-US", server_id="filesrv", local_api_key="filekey"
+        )
+
+    def test_env_takes_precedence_over_key_file(self, monkeypatch):
+        save_local_key("filekey", "filesrv")
+        monkeypatch.setenv(mcp_server.WRITE_KEY_ENV, "envkey")
+        with patch("pyzotero._helpers.get_zotero_client") as client:
+            mcp_server._write_client()
+        client.assert_called_once_with("en-US", server_id=None, local_api_key="envkey")
 
 
 class TestWriteTools:

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -1005,6 +1005,43 @@ class ZoteroTests(unittest.TestCase):
 
         self.assertTrue(resp)
 
+    def testMoveToCollection(self):
+        """Tests moving an item between collections in one request"""
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+        mock.register(
+            "PATCH",
+            "https://api.zotero.org/users/myuserID/items/ITEMKEY",
+            status=204,
+        )
+        item = {
+            "key": "ITEMKEY",
+            "version": 5,
+            "data": {"collections": ["FROM", "OTHER"]},
+        }
+        resp = zot.moveto_collection("FROM", "TO", item)
+        request = mock.last_request()
+        self.assertEqual(request.method, "PATCH")
+        self.assertEqual(request.headers["If-Unmodified-Since-Version"], "5")
+        body = json.loads(request.body.decode("utf-8"))
+        # the source is gone, the destination is present, others are kept
+        self.assertEqual(body["collections"], ["OTHER", "TO"])
+        self.assertTrue(resp)
+
+    def testMoveToCollectionIsIdempotent(self):
+        """An item already in the destination is not listed there twice"""
+        mock = MockClient()
+        zot = z.Zotero("myuserID", "user", "myuserkey", client=mock.client)
+        mock.register(
+            "PATCH",
+            "https://api.zotero.org/users/myuserID/items/ITEMKEY",
+            status=204,
+        )
+        item = {"key": "ITEMKEY", "version": 5, "data": {"collections": ["TO"]}}
+        zot.moveto_collection("FROM", "TO", item)
+        body = json.loads(mock.last_request().body.decode("utf-8"))
+        self.assertEqual(body["collections"], ["TO"])
+
     def testDeleteItem(self):
         """Tests deleting an item"""
         mock = MockClient()


### PR DESCRIPTION
Closes #361 and #362.

## What changes

**Client**
- `Zotero.moveto_collection(from_collection, to_collection, item)`: moves an item between collections in one PATCH request. A `deletefrom_collection` call followed by `addto_collection` fails: the first call changes the item version that the second sends as its precondition. The three membership methods now share one PATCH helper. Documented in `doc/index.rst`.

**Stored local API key**
- `pyzotero authorize` now writes a permanent key (with the server ID) to `$XDG_CONFIG_HOME/pyzotero/local-api-key.json` (`~/.config/...` if unset), mode 0600. `--no-store` keeps the old print-only behaviour.
- The MCP server reads the key from that file when `PYZOTERO_LOCAL_API_KEY` is not set, so one `authorize` run serves both the CLI and the MCP server. The environment takes precedence over the file. This is a small widening of #362's scope; it is what makes the CLI gate in #361 work without a second copy of the key.

**MCP server (#362)**
- `remove_from_collection(item_key, collection_key)` and `move_to_collection(item_key, from_collection_key, to_collection_key)`, both behind `--enable-writes`.

**CLI (#361)**
- `createcollection NAME [--parent KEY]`
- `addtocollection COLLECTION_KEY ITEM_KEY...`
- `removefromcollection COLLECTION_KEY ITEM_KEY...`
- `movetocollection --from KEY --to KEY ITEM_KEY...`

Each accepts `--json` and reports the keys touched. Without a stored key they exit 1 with a message naming `pyzotero authorize`. The membership commands change items one at a time; on failure the error names the item and lists the items already changed, so a batch can be resumed.

## Tests

New `tests/test_cli.py` (CliRunner) and `tests/test_local_key.py`; additions to `tests/test_mcp.py` and `tests/test_zotero.py`. 227 tests pass. Sphinx builds `doc/index.rst` with `-W`.

https://claude.ai/code/session_01JrhckdLFmG6YKfjjy7LYAB