### PR TITLE
Bump minor version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyzotero"
-version = "1.14.0"
+version = "1.15.0"
 description = "Python wrapper for the Zotero API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1336,7 +1336,7 @@ wheels = [
 
 [[package]]
 name = "pyzotero"
-version = "1.14.0"
+version = "1.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "bibtexparser" },


### PR DESCRIPTION
1.14.0 -> 1.15.0 via `uv version --bump minor`. Top of the stack: #363, #364, this.

https://claude.ai/code/session_01JrhckdLFmG6YKfjjy7LYAB