### PR TITLE
Add createitem and listitemfields CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Versions reported by the local API are unrelated to web API versions, and are ty
 * Using [pip][10]: `pip install pyzotero`
 * Using Anaconda: `conda install conda-forge::pyzotero`
 
-Pyzotero also provides an optional [CLI](#command-line-interface) and [MCP server](#mcp-server) for working with a local Zotero library. Both require Zotero 7 with local API access enabled: Zotero > Settings > Advanced > "Allow other applications on this computer to communicate with Zotero". Both are read-only unless you run `pyzotero authorize`, which stores a local API key. With that key, the CLI's collection commands can write, and the MCP server can write if started with `--enable-writes`. Both console scripts are installed whichever extra you choose; one whose extra is missing exits with a message naming the extra to install.
+Pyzotero also provides an optional [CLI](#command-line-interface) and [MCP server](#mcp-server) for working with a local Zotero library. Both require Zotero 7 with local API access enabled: Zotero > Settings > Advanced > "Allow other applications on this computer to communicate with Zotero". Both are read-only unless you run `pyzotero authorize`, which stores a local API key. With that key, the CLI's write commands can write, and the MCP server can write if started with `--enable-writes`. Both console scripts are installed whichever extra you choose; one whose extra is missing exits with a message naming the extra to install.
 
 # Command-Line Interface
 
-Pyzotero includes an optional CLI for searching and querying your local Zotero library, and for managing its collections.
+Pyzotero includes an optional CLI for searching and querying your local Zotero library, and for adding items to it and managing its collections.
 
 ## Installing the CLI
 
@@ -101,8 +101,15 @@ pyzotero listcollections
 # List available item types
 pyzotero itemtypes
 
+# List the fields and creator types that one item type accepts
+pyzotero listitemfields journalArticle
+
 # Obtain and store a local API key, which permits writes from the CLI and the MCP server
 pyzotero authorize --app-name "Claude Desktop"
+
+# Create items from a JSON file, or from standard input
+pyzotero createitem items.json --collection FD9AUNP2 --tag "to read"
+cat items.json | pyzotero createitem -
 
 # Create a collection, nested under an existing one
 pyzotero createcollection "Frankenstein Cities" --parent FD9AUNP2
@@ -113,9 +120,24 @@ pyzotero removefromcollection FD9AUNP2 ABC123
 pyzotero movetocollection --from FD9AUNP2 --to X7Y8Z9W0 ABC123 DEF456
 ```
 
-## Collection Commands
+## Write Commands
 
-`createcollection`, `addtocollection`, `removefromcollection` and `movetocollection` write to your library. They need a stored local API key: run `pyzotero authorize` once and choose "Always Allow". Without a key, they exit with a message that says so. Each accepts `--json` and reports the keys it touched. The membership commands change items one at a time; if one fails, the error names the item and lists the items already changed, so that you can resume from there. `movetocollection` changes each item in one request, so an item's membership of other collections is kept.
+`createitem`, `createcollection`, `addtocollection`, `removefromcollection` and `movetocollection` write to your library. They need a stored local API key: run `pyzotero authorize` once and choose "Always Allow". Without a key, they exit with a message that says so. Each accepts `--json` and reports the keys it touched. The membership commands change items one at a time; if one fails, the error names the item and lists the items already changed, so that you can resume from there. `movetocollection` changes each item in one request, so an item's membership of other collections is kept.
+
+`createitem` takes the path of a JSON file, or `-` for standard input. The file holds one item object, or a list of them, in Zotero's item-data format:
+
+```json
+[
+  {
+    "itemType": "book",
+    "title": "Frankenstein",
+    "creators": [{"creatorType": "author", "lastName": "Shelley", "firstName": "Mary"}],
+    "date": "1818"
+  }
+]
+```
+
+`--collection` files every created item under one collection, and `--tag`, which you can repeat, tags every created item; collections and tags that an item already carries are kept. The item type and the field names of every item are checked against the library's schema before anything is sent, so one invalid item stops the whole batch and the message names its position in the list. `pyzotero itemtypes` lists the item types, and `pyzotero listitemfields TYPE` lists the fields of one type. Zotero accepts up to 50 items in one call.
 
 ## Search Behaviour
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -159,6 +159,12 @@ List available item types:
 
         pyzotero itemtypes
 
+List the fields and creator types that one item type accepts:
+
+    .. code-block:: bash
+
+        pyzotero listitemfields journalArticle
+
 Item and Attachment Commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -201,8 +207,8 @@ List tags from a specific collection:
 
         pyzotero tags --collection ABC123
 
-Collection Commands
-~~~~~~~~~~~~~~~~~~~
+Write Commands
+~~~~~~~~~~~~~~
 
 These commands write to your library, so they need a local API key. Run ``pyzotero authorize`` once and choose "Always Allow" in Zotero's dialog. The key is stored in ``$XDG_CONFIG_HOME/pyzotero/local-api-key.json`` (``~/.config/pyzotero/local-api-key.json`` if that variable is unset), readable only by you. Setting ``PYZOTERO_LOCAL_API_KEY`` in the environment takes precedence over the file. Without a key, the commands exit with a message that says so.
 
@@ -211,6 +217,29 @@ Obtain and store a key:
     .. code-block:: bash
 
         pyzotero authorize --app-name "My tool"
+
+Create items from a JSON file, or from standard input:
+
+    .. code-block:: bash
+
+        pyzotero createitem item.json
+        cat items.json | pyzotero createitem -
+        pyzotero createitem items.json --collection FD9AUNP2 --tag "to read" --json
+
+The file holds one item object, or a list of them, in Zotero's item-data format:
+
+    .. code-block:: json
+
+        [
+          {
+            "itemType": "book",
+            "title": "Frankenstein",
+            "creators": [{"creatorType": "author", "lastName": "Shelley", "firstName": "Mary"}],
+            "date": "1818"
+          }
+        ]
+
+``--collection`` files every created item under one collection, and ``--tag``, which you can repeat, tags every created item. Collections and tags that an item already carries are kept. The item type and the field names of every item are checked against the library's schema before anything is sent, so one invalid item stops the whole batch and the message names its position in the list. ``pyzotero itemtypes`` lists the item types, and ``pyzotero listitemfields TYPE`` lists the fields of one type. Zotero accepts up to 50 items in one call.
 
 Create a collection, at the top level or nested under ``--parent``:
 
@@ -236,7 +265,7 @@ Move items from one collection to another:
 
         pyzotero movetocollection --from FD9AUNP2 --to X7Y8Z9W0 ABC123 DEF456
 
-Each command accepts ``--json`` and reports the keys it touched. The membership commands change items one at a time. If one fails, the error names that item and lists the items already changed, so that you can resume. ``movetocollection`` changes each item in one request: its membership of other collections is kept.
+Each command accepts ``--json`` and reports the keys it touched. The membership commands change items one at a time. If one fails, the error names that item and lists the items already changed, so that you can resume. ``movetocollection`` changes each item in one request: its membership of other collections is kept. If Zotero rejects an item that ``createitem`` sends, the error gives its reason and names the items that were created.
 
 DOI Index
 ~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyzotero"
-version = "1.15.0"
+version = "1.15.1"
 description = "Python wrapper for the Zotero API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pyzotero/_helpers.py
+++ b/src/pyzotero/_helpers.py
@@ -9,9 +9,26 @@ from pathlib import Path
 from typing import Any
 
 from pyzotero import zotero
+from pyzotero.errors import InvalidItemFieldsError
 
 LOCAL_KEY_ENV = "PYZOTERO_LOCAL_API_KEY"
 LOCAL_SERVER_ID_ENV = "PYZOTERO_LOCAL_SERVER_ID"
+
+# Keys that Zotero accepts on an item of any type, so no per-type field list
+# contains them.
+COMMON_ITEM_KEYS = frozenset(
+    {
+        "collections",
+        "creators",
+        "dateAdded",
+        "dateModified",
+        "itemType",
+        "key",
+        "relations",
+        "tags",
+        "version",
+    }
+)
 
 
 def get_zotero_client(
@@ -98,6 +115,74 @@ def get_write_client(locale: str = "en-US") -> zotero.Zotero:
         )
         raise RuntimeError(msg)
     return get_zotero_client(locale, server_id=server_id, local_api_key=key)
+
+
+def describe_item_type(zot: zotero.Zotero, item_type: str) -> dict[str, Any]:
+    """Return the fields and creator types that ``item_type`` accepts.
+
+    Args:
+        zot: a Zotero client.
+        item_type: a Zotero item type, e.g. "journalArticle".
+
+    Returns:
+        A dict with the item type, its field names and its creator types.
+
+    """
+    return {
+        "itemType": item_type,
+        "fields": [
+            f["field"]  # ty: ignore[invalid-argument-type]
+            for f in zot.item_type_fields(item_type)
+        ],
+        "creatorTypes": [
+            c["creatorType"]  # ty: ignore[invalid-argument-type]
+            for c in zot.item_creator_types(item_type)
+        ],
+    }
+
+
+def validate_items(zot: zotero.Zotero, items: list[Any]) -> None:
+    """Check the type and the field names of each item against the schema.
+
+    Args:
+        zot: a Zotero client.
+        items: items in Zotero's item-data format, before they are sent.
+
+    Raises:
+        InvalidItemFieldsError: an item is not an object, has no item type,
+            has an item type that the library does not know, or has a field
+            that its item type does not accept. The message names the
+            position of the item in ``items``.
+
+    """
+    valid_types = {
+        t["itemType"]  # ty: ignore[invalid-argument-type]
+        for t in zot.item_types()
+    }
+    fields_by_type: dict[str, set[str]] = {}
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            msg = f"Item at index {index} is not a JSON object"
+            raise InvalidItemFieldsError(msg)
+        item_type = item.get("itemType")
+        if not item_type:
+            msg = f"Item at index {index} has no itemType"
+            raise InvalidItemFieldsError(msg)
+        if item_type not in valid_types:
+            msg = f"Item at index {index} has unknown itemType {item_type!r}"
+            raise InvalidItemFieldsError(msg)
+        if item_type not in fields_by_type:
+            fields_by_type[item_type] = {
+                f["field"]  # ty: ignore[invalid-argument-type]
+                for f in zot.item_type_fields(item_type)
+            }
+        unknown = sorted(set(item) - fields_by_type[item_type] - COMMON_ITEM_KEYS)
+        if unknown:
+            msg = (
+                f"Item at index {index} of type {item_type!r} has fields that "
+                f"the type does not accept: {', '.join(unknown)}"
+            )
+            raise InvalidItemFieldsError(msg)
 
 
 def normalise_doi(doi: str) -> str:

--- a/src/pyzotero/cli.py
+++ b/src/pyzotero/cli.py
@@ -571,7 +571,7 @@ def authorize(ctx: Any, app_name: str, no_store: bool) -> None:
 
     A permanent key is stored in a file that only you can read
     ($XDG_CONFIG_HOME/pyzotero/local-api-key.json, or the same path under
-    ~/.config). The CLI's collection commands and the MCP server, when
+    ~/.config). The CLI's write commands and the MCP server, when
     started with --enable-writes, read the key from that file. Setting
     PYZOTERO_LOCAL_API_KEY in the environment takes precedence over it.
 
@@ -607,7 +607,7 @@ def authorize(ctx: Any, app_name: str, no_store: bool) -> None:
     path = save_local_key(result["key"], zot.server_id)
     click.echo(
         f"\nThis key persists. Stored it in {path}.\n"
-        "The CLI's collection commands use it. So does the MCP server when\n"
+        "The CLI's write commands use it. So does the MCP server when\n"
         "started with --enable-writes; no environment variable is needed.",
         err=True,
     )

--- a/src/pyzotero/cli.py
+++ b/src/pyzotero/cli.py
@@ -6,7 +6,7 @@ import functools
 import json
 import sys
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import IO, Any, TypeVar
 
 import click
 import httpx2
@@ -16,12 +16,14 @@ from pyzotero._helpers import (
     annotate_with_library,
     build_doi_index,
     build_doi_index_full,
+    describe_item_type,
     format_creators,
     format_s2_paper,
     get_write_client,
     get_zotero_client,
     normalise_doi,
     save_local_key,
+    validate_items,
 )
 from pyzotero.semantic_scholar import (
     PaperNotFoundError,
@@ -101,6 +103,47 @@ def _change_membership(
             raise RuntimeError(msg) from exc
         done.append(key)
     return done
+
+
+def _read_items(source: IO[str]) -> list[Any]:
+    """Read one item, or a list of items, from an open JSON source.
+
+    A single object becomes a list of one item, so that the caller always
+    gets a list. Raises RuntimeError, which the error handler reports, if
+    the content is not JSON, or holds neither an object nor a list.
+    """
+    name = getattr(source, "name", "input")
+    try:
+        parsed = json.loads(source.read())
+    except ValueError as exc:
+        msg = f"{name} does not hold valid JSON: {exc}"
+        raise RuntimeError(msg) from exc
+    if isinstance(parsed, dict):
+        return [parsed]
+    if not isinstance(parsed, list):
+        msg = f"{name} must hold a JSON object or a list of objects"
+        raise TypeError(msg)
+    return parsed
+
+
+def _attach(
+    item: dict[str, Any], tags: tuple[str, ...], collection: str | None
+) -> None:
+    """Add ``tags`` and ``collection`` to an item, in place.
+
+    Tags and collections that the item already has are kept. A tag that the
+    item gives as a plain string becomes a Zotero tag object.
+    """
+    attached = [t if isinstance(t, dict) else {"tag": t} for t in item.get("tags", [])]
+    present = {t.get("tag") for t in attached}
+    attached.extend({"tag": tag} for tag in tags if tag not in present)
+    if attached:
+        item["tags"] = attached
+    if collection:
+        collections = list(item.get("collections", []))
+        if collection not in collections:
+            collections.append(collection)
+        item["collections"] = collections
 
 
 def _run_s2_lookup(
@@ -485,6 +528,27 @@ def itemtypes(ctx: Any) -> None:
 
 
 @main.command()
+@click.argument("itemtype")
+@click.pass_context
+@cli_error_handler
+def listitemfields(ctx: Any, itemtype: str) -> None:
+    """List the fields and creator types that one item type accepts.
+
+    Run this before 'pyzotero createitem' to find the fields of an item
+    type. 'pyzotero itemtypes' lists the types themselves.
+
+    Examples:
+        pyzotero listitemfields journalArticle
+
+        pyzotero listitemfields book
+
+    """
+    zot = _zot_from_ctx(ctx)
+
+    click.echo(json.dumps(describe_item_type(zot, itemtype), indent=2))
+
+
+@main.command()
 @click.option(
     "--app-name",
     default="Pyzotero",
@@ -547,6 +611,92 @@ def authorize(ctx: Any, app_name: str, no_store: bool) -> None:
         "started with --enable-writes; no environment variable is needed.",
         err=True,
     )
+
+
+@main.command()
+@click.argument("source", type=click.File("r"))
+@click.option(
+    "--collection",
+    help="Key of a collection. Every created item is filed under it.",
+)
+@click.option(
+    "--tag",
+    "tags",
+    multiple=True,
+    help="Tag for every created item (can be specified multiple times)",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output results as JSON",
+)
+@click.pass_context
+@cli_error_handler
+def createitem(
+    ctx: Any,
+    source: IO[str],
+    collection: str | None,
+    tags: tuple[str, ...],
+    output_json: bool,
+) -> None:
+    """Create one or more items from a JSON file, or from '-' for stdin.
+
+    SOURCE holds one item object, or a list of them, in Zotero's item-data
+    format: an "itemType" and the fields that the type accepts, for example
+    {"itemType": "book", "title": "Frankenstein", "creators": [...]}. Run
+    'pyzotero itemtypes' for the item types, and 'pyzotero listitemfields
+    TYPE' for the fields of one type.
+
+    The item type and the field names of every item are checked before
+    anything is sent. One invalid item stops the whole batch, and the
+    message names its position in the list. Zotero accepts up to 50 items
+    in one call.
+
+    Needs a stored local API key: run 'pyzotero authorize' first.
+
+    Examples:
+        pyzotero createitem item.json
+
+        cat items.json | pyzotero createitem -
+
+        pyzotero createitem items.json --collection FD9AUNP2 --tag "to read"
+
+        pyzotero createitem items.json --json
+
+    """
+    zot = _write_zot_from_ctx(ctx)
+    items = _read_items(source)
+    if not items:
+        msg = "No items to create"
+        raise RuntimeError(msg)
+    validate_items(zot, items)
+    for item in items:
+        _attach(item, tags, collection)
+    resp = zot.create_items(items)
+    success = resp.get("success") or {}
+    created = [success[pos] for pos in sorted(success, key=int)]
+    failed = resp.get("failed") or {}
+    if failed:
+        made = ", ".join(created) if created else "none"
+        msg = (
+            f"Zotero rejected {len(failed)} of {len(items)} items: {failed} "
+            f"(created {len(created)}: {made})"
+        )
+        raise RuntimeError(msg)
+    if output_json:
+        click.echo(
+            json.dumps(
+                {
+                    "created": created,
+                    "collection": collection or None,
+                    "tags": list(tags),
+                },
+                indent=2,
+            )
+        )
+    else:
+        click.echo(f"Created {len(created)} items: {', '.join(created)}")
 
 
 @main.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,11 +30,37 @@ def runner():
     return CliRunner()
 
 
+ITEM_TYPE_FIELDS = {
+    "book": ["title", "abstractNote", "date", "publisher", "numPages"],
+    "journalArticle": ["title", "abstractNote", "date", "publicationTitle", "DOI"],
+}
+
+CREATOR_TYPES = {
+    "book": ["author", "editor"],
+    "journalArticle": ["author", "contributor"],
+}
+
+
+def _schema_mock(mock):
+    """Give a mock client the schema calls that item validation makes."""
+    mock.item_types.return_value = [
+        {"itemType": name, "localized": name} for name in ITEM_TYPE_FIELDS
+    ]
+    mock.item_type_fields.side_effect = lambda t: [
+        {"field": f, "localized": f} for f in ITEM_TYPE_FIELDS[t]
+    ]
+    mock.item_creator_types.side_effect = lambda t: [
+        {"creatorType": c, "localized": c} for c in CREATOR_TYPES[t]
+    ]
+    return mock
+
+
 @pytest.fixture
 def write_zot():
     """Patch get_write_client to return a mock, and return the mock."""
-    mock = MagicMock()
+    mock = _schema_mock(MagicMock())
     mock.create_collections.return_value = {"success": {"0": "NEWCOLL"}, "failed": {}}
+    mock.create_items.return_value = {"success": {"0": "NEWITEM"}, "failed": {}}
     mock.item.side_effect = lambda key: {
         "key": key,
         "version": 3,
@@ -42,6 +68,18 @@ def write_zot():
     }
     with patch("pyzotero.cli.get_write_client", return_value=mock):
         yield mock
+
+
+@pytest.fixture
+def item_file(tmp_path):
+    """Return a function that writes a payload to a JSON file and names it."""
+
+    def write(payload, name="items.json"):
+        path = tmp_path / name
+        path.write_text(json.dumps(payload))
+        return str(path)
+
+    return write
 
 
 class TestKeyGate:
@@ -59,10 +97,199 @@ class TestKeyGate:
         assert result.exit_code == 1
         assert "pyzotero authorize" in result.output
 
+    def test_createitem_refuses_without_key(self, runner, item_file):
+        """The createitem argument is a file, so it needs its own case"""
+        path = item_file({"itemType": "book", "title": "A Book"})
+        result = runner.invoke(cli.main, ["createitem", path])
+        assert result.exit_code == 1
+        assert "pyzotero authorize" in result.output
+
     def test_locale_reaches_write_client(self, runner, write_zot):
         with patch("pyzotero.cli.get_write_client", return_value=write_zot) as gwc:
             runner.invoke(cli.main, ["--locale", "de-DE", "createcollection", "N"])
         gwc.assert_called_once_with("de-DE")
+
+
+class TestCreateItem:
+    def test_single_item(self, runner, write_zot, item_file):
+        path = item_file({"itemType": "book", "title": "A Book"})
+        result = runner.invoke(cli.main, ["createitem", path])
+        assert result.exit_code == 0, result.output
+        assert "Created 1 items: NEWITEM" in result.output
+        assert write_zot.create_items.call_args[0][0] == [
+            {"itemType": "book", "title": "A Book"}
+        ]
+
+    def test_list_of_items(self, runner, write_zot, item_file):
+        write_zot.create_items.return_value = {
+            "success": {"0": "KEY1", "1": "KEY2"},
+            "failed": {},
+        }
+        path = item_file(
+            [
+                {"itemType": "book", "title": "One"},
+                {"itemType": "journalArticle", "title": "Two", "DOI": "10.1234/x"},
+            ]
+        )
+        result = runner.invoke(cli.main, ["createitem", path])
+        assert result.exit_code == 0, result.output
+        assert "Created 2 items: KEY1, KEY2" in result.output
+        assert len(write_zot.create_items.call_args[0][0]) == len(["One", "Two"])
+
+    def test_stdin(self, runner, write_zot):
+        result = runner.invoke(
+            cli.main,
+            ["createitem", "-"],
+            input=json.dumps({"itemType": "book", "title": "Piped"}),
+        )
+        assert result.exit_code == 0, result.output
+        assert "NEWITEM" in result.output
+        assert write_zot.create_items.call_args[0][0] == [
+            {"itemType": "book", "title": "Piped"}
+        ]
+
+    def test_creators_and_other_common_keys_are_accepted(
+        self, runner, write_zot, item_file
+    ):
+        path = item_file(
+            {
+                "itemType": "book",
+                "title": "A Book",
+                "creators": [{"creatorType": "author", "lastName": "Shelley"}],
+                "collections": ["EXISTING"],
+                "relations": {},
+            }
+        )
+        result = runner.invoke(cli.main, ["createitem", path])
+        assert result.exit_code == 0, result.output
+
+    def test_invalid_itemtype(self, runner, write_zot, item_file):
+        path = item_file(
+            [{"itemType": "book", "title": "Fine"}, {"itemType": "notAType"}]
+        )
+        result = runner.invoke(cli.main, ["createitem", path])
+        assert result.exit_code == 1
+        assert "index 1" in result.output
+        assert "notAType" in result.output
+        write_zot.create_items.assert_not_called()
+
+    def test_invalid_field(self, runner, write_zot, item_file):
+        path = item_file({"itemType": "book", "title": "A Book", "issue": "3"})
+        result = runner.invoke(cli.main, ["createitem", path])
+        assert result.exit_code == 1
+        assert "index 0" in result.output
+        assert "issue" in result.output
+        write_zot.create_items.assert_not_called()
+
+    def test_missing_itemtype(self, runner, write_zot, item_file):
+        path = item_file({"title": "No type"})
+        result = runner.invoke(cli.main, ["createitem", path])
+        assert result.exit_code == 1
+        assert "no itemType" in result.output
+
+    def test_collection_option(self, runner, write_zot, item_file):
+        path = item_file(
+            [
+                {"itemType": "book", "title": "One"},
+                {"itemType": "book", "title": "Two", "collections": ["FD9AUNP2"]},
+            ]
+        )
+        result = runner.invoke(
+            cli.main, ["createitem", path, "--collection", "FD9AUNP2"]
+        )
+        assert result.exit_code == 0, result.output
+        sent = write_zot.create_items.call_args[0][0]
+        # the key is added once, and an item that already has it is unchanged
+        assert [i["collections"] for i in sent] == [["FD9AUNP2"], ["FD9AUNP2"]]
+
+    def test_tag_option(self, runner, write_zot, item_file):
+        path = item_file({"itemType": "book", "title": "One", "tags": ["existing"]})
+        result = runner.invoke(
+            cli.main, ["createitem", path, "--tag", "one", "--tag", "two"]
+        )
+        assert result.exit_code == 0, result.output
+        sent = write_zot.create_items.call_args[0][0]
+        # a string tag becomes a tag object, and the new tags follow it
+        assert sent[0]["tags"] == [
+            {"tag": "existing"},
+            {"tag": "one"},
+            {"tag": "two"},
+        ]
+
+    def test_tag_is_not_repeated(self, runner, write_zot, item_file):
+        path = item_file({"itemType": "book", "title": "One", "tags": [{"tag": "one"}]})
+        runner.invoke(cli.main, ["createitem", path, "--tag", "one"])
+        sent = write_zot.create_items.call_args[0][0]
+        assert sent[0]["tags"] == [{"tag": "one"}]
+
+    def test_json_output(self, runner, write_zot, item_file):
+        path = item_file({"itemType": "book", "title": "A Book"})
+        result = runner.invoke(
+            cli.main,
+            ["createitem", path, "--collection", "COLL1", "--tag", "t", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {
+            "created": ["NEWITEM"],
+            "collection": "COLL1",
+            "tags": ["t"],
+        }
+
+    def test_rejection_names_failures_and_progress(self, runner, write_zot, item_file):
+        write_zot.create_items.return_value = {
+            "success": {"0": "KEY1"},
+            "failed": {"1": {"code": 400, "message": "Invalid field"}},
+        }
+        path = item_file(
+            [{"itemType": "book", "title": "One"}, {"itemType": "book", "title": "Two"}]
+        )
+        result = runner.invoke(cli.main, ["createitem", path])
+        assert result.exit_code == 1
+        assert "rejected 1 of 2 items" in result.output
+        assert "Invalid field" in result.output
+        assert "KEY1" in result.output
+
+    def test_malformed_json(self, runner, write_zot, tmp_path):
+        path = tmp_path / "broken.json"
+        path.write_text("{not json")
+        result = runner.invoke(cli.main, ["createitem", str(path)])
+        assert result.exit_code == 1
+        assert "valid JSON" in result.output
+
+    def test_scalar_json(self, runner, write_zot, item_file):
+        result = runner.invoke(cli.main, ["createitem", item_file("a string")])
+        assert result.exit_code == 1
+        assert "object or a list of objects" in result.output
+
+    def test_empty_list(self, runner, write_zot, item_file):
+        result = runner.invoke(cli.main, ["createitem", item_file([])])
+        assert result.exit_code == 1
+        assert "No items to create" in result.output
+
+    def test_missing_file(self, runner, write_zot, tmp_path):
+        result = runner.invoke(cli.main, ["createitem", str(tmp_path / "absent.json")])
+        assert result.exit_code == USAGE_ERROR
+
+
+class TestListItemFields:
+    @pytest.fixture
+    def read_zot(self):
+        mock = _schema_mock(MagicMock())
+        with patch("pyzotero.cli.get_zotero_client", return_value=mock):
+            yield mock
+
+    def test_fields_and_creator_types(self, runner, read_zot):
+        result = runner.invoke(cli.main, ["listitemfields", "book"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {
+            "itemType": "book",
+            "fields": ITEM_TYPE_FIELDS["book"],
+            "creatorTypes": CREATOR_TYPES["book"],
+        }
+
+    def test_requires_an_item_type(self, runner, read_zot):
+        result = runner.invoke(cli.main, ["listitemfields"])
+        assert result.exit_code == USAGE_ERROR
 
 
 class TestCreateCollection:

--- a/uv.lock
+++ b/uv.lock
@@ -1310,7 +1310,7 @@ wheels = [
 
 [[package]]
 name = "pyzotero"
-version = "1.15.0"
+version = "1.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "bibtexparser" },


### PR DESCRIPTION
Adds a `createitem` CLI command, which creates one or more items in the local Zotero library through the local API, and a `listitemfields` read command that supports it.

## createitem

    pyzotero createitem [--collection KEY] [--tag TAG]... [--json] SOURCE

`SOURCE` is the path of a JSON file, or `-` for standard input. It holds one item object, or a list of them, in Zotero's item-data format (`itemType` plus the fields that the type accepts, `creators`, `tags`, `collections`).

- `--collection KEY` files every created item under one collection.
- `--tag TAG`, which can be repeated, tags every created item.
- Collections and tags that an item already carries are kept, and a tag given as a plain string becomes a Zotero tag object.
- `--json` prints the created keys, the collection and the tags as JSON; the default output is a line naming the created keys.

The item type and the field names of every item are checked against the library's schema before anything is sent, so one invalid item stops the whole batch and the message names its position in the list. If Zotero rejects an item, the error gives its reason and names the items that were created.

Like the other write commands, `createitem` needs a stored local API key: run `pyzotero authorize` first.

## listitemfields

    pyzotero listitemfields ITEMTYPE

Prints the fields and creator types that one item type accepts, so that the fields of a `createitem` payload can be looked up. This is the CLI equivalent of the MCP server's `list_item_fields` tool, which had no counterpart in the CLI.

## Shared code

`describe_item_type` and `validate_items` live in `pyzotero/_helpers.py`, beside the other helpers that the CLI and the MCP server share. `createitem` sends its payload through `Zotero.create_items`, the same call that the MCP server's `create_item` tool uses.

## Documentation

The README and `doc/index.rst` document both commands. The "Collection Commands" section in each is now "Write Commands", because it no longer covers collections alone.

## Tests

18 new tests in `tests/test_cli.py`, in the style of the existing collection-command tests (a `MagicMock` write client, a `CliRunner`): a single item, a list of items, standard input, the common keys (`creators`, `collections`, `relations`), an unknown item type, a field the type does not accept, a missing item type, `--collection` (including an item that already has the key), `--tag` (including a string tag and a tag the item already has), `--json`, a Zotero rejection, malformed JSON, a scalar payload, an empty list, a missing file, the missing-key gate, and the `listitemfields` output. The whole suite passes: 250 passed.

https://claude.ai/code/session_01Ddv9diNdjR8KoBouw7AfiZ
