### PR TITLE
Install extras in CI so the CLI and MCP tests run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         cache-dependency-glob: "**/pyproject.toml"
 
     - name: Install the project and deps
-      run: uv sync --dev --locked
+      run: uv sync --dev --locked --all-extras
 
     - name: Run tests
       run: uv run pytest --junit-xml=junit.xml


### PR DESCRIPTION
`uv sync --dev --locked` does not install the `cli` and `mcp` extras, so `tests/test_cli.py` and `tests/test_mcp.py` have been skipping themselves (`pytest.importorskip`) on every CI run. This is why #367's breakage was invisible, and it would have hidden the `createitem` tests from #368 as well.

Change: `uv sync --dev --locked --all-extras`. Verified locally that the locked sync resolves with all extras and that the full suite (231 tests on current main) passes with them installed.

https://claude.ai/code/session_01Ddv9diNdjR8KoBouw7AfiZ